### PR TITLE
Add reset via CANrange on init under certain distance

### DIFF
--- a/src/main/java/frc/alotobots/reefscape/subsystems/elevator/ElevatorSubsystem.java
+++ b/src/main/java/frc/alotobots/reefscape/subsystems/elevator/ElevatorSubsystem.java
@@ -24,6 +24,7 @@ import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.alotobots.reefscape.subsystems.elevator.constants.ControlType;
 import frc.alotobots.reefscape.subsystems.elevator.io.ElevatorIO;
 import frc.alotobots.reefscape.subsystems.elevator.io.ElevatorIOInputsAutoLogged;
+import frc.alotobots.util.Elastic;
 import org.littletonrobotics.junction.Logger;
 
 /**
@@ -54,6 +55,18 @@ public class ElevatorSubsystem extends SubsystemBase {
    */
   public ElevatorSubsystem(ElevatorIO io) {
     this.io = io;
+
+    // Set the rotor positions based on CANrange on startup for better reliability
+    if (inputs.canrangeConnected && inputs.canrangeDistance.lt(CAN_RANGE_MAX_VALID_DISTANCE)) {
+      io.resetRotorPositions(inputs.canrangeDistance);
+    } else if (inputs.canrangeConnected) {
+      Logger.recordOutput("Elevator/Faults/CANrangeTooFarDuringInit", true);
+      Elastic.sendAlert(
+          new Elastic.ElasticNotification(
+              Elastic.ElasticNotification.NotificationLevel.WARNING,
+              "Failed to apply offset to elevator",
+              "Verify that elevator is at zero position!"));
+    }
   }
 
   /**

--- a/src/main/java/frc/alotobots/reefscape/subsystems/elevator/constants/ElevatorConstants.java
+++ b/src/main/java/frc/alotobots/reefscape/subsystems/elevator/constants/ElevatorConstants.java
@@ -30,6 +30,8 @@ public final class ElevatorConstants {
   /** How long the elevator must be "at position" to classify as "at position" */
   public static final Time AT_SET_POINT_TIME_THRESHOLD = Seconds.of(.2);
 
+  public static final Distance CAN_RANGE_MAX_VALID_DISTANCE = Meters.of(.5);
+
   /** Maximum open loop percent output */
   public static final double MAX_OPEN_LOOP_PERCENTAGE = 0.5;
 

--- a/src/main/java/frc/alotobots/reefscape/subsystems/elevator/io/ElevatorIO.java
+++ b/src/main/java/frc/alotobots/reefscape/subsystems/elevator/io/ElevatorIO.java
@@ -117,6 +117,14 @@ public interface ElevatorIO {
    */
   public default void setElevatorBrakeMode(boolean brake) {}
 
+  /**
+   * Resets both motors' (left and right) dead-reckoning position to the rotor count consistent with
+   * the input height
+   *
+   * @param height The height that the elevator should reference as zero
+   */
+  public default void resetRotorPositions(Distance height) {}
+
   /** Stops all motors */
   public default void stop() {}
 }

--- a/src/main/java/frc/alotobots/reefscape/subsystems/elevator/io/ElevatorIOTalonFXReal.java
+++ b/src/main/java/frc/alotobots/reefscape/subsystems/elevator/io/ElevatorIOTalonFXReal.java
@@ -308,6 +308,17 @@ public class ElevatorIOTalonFXReal implements ElevatorIO {
     leftTalon.setNeutralMode(brake ? NeutralModeValue.Brake : NeutralModeValue.Coast);
   }
 
+  /**
+   * Resets the rotor sensors of both motors to be equal to the given height
+   *
+   * @param height The height off the floor the elevator is at
+   */
+  @Override
+  public void resetRotorPositions(Distance height) {
+    leftTalon.setPosition(heightToTalonFX(height));
+    rightTalon.setPosition(heightToTalonFX(height));
+  }
+
   /** Stops all elevator motor movement. */
   @Override
   public void stop() {


### PR DESCRIPTION
# Mechanism Change PR: Elevator

## Description
Added elevator safety limits such as reseting position via CANrange on boot to ensure that no errors are made. Submitted as draft as not all features are complete
## Safety Checks
- [ ] Motor current limits properly configured
- [ ] Software limits implemented and tested
- [ ] Mechanism collision prevention validated

## Code Quality
- [ ] Code follows team style guide
- [ ] Comments added for complex logic
- [ ] Constants defined in appropriate subsystem constants file
- [ ] No magic numbers in code

## Logging
- [ ] Full AdvantageKit logging implemented for all subsystem states
- [ ] Replay support verified with AdvantageScope
- [ ] Custom AdvantageScope visualizations added if needed

## Robot Testing
- [ ] Tested on competition bot
- [ ] Tested with full battery (>12V)
- [ ] Tested with 11.8V battery (if possible)
- [ ] Tested while other mechanisms running
- [ ] Tested in all robot positions/configurations

## Competition Readiness
- [ ] Compatible with all auto modes
- [ ] Works with current operator controls or has been updated
- [ ] Dashboard widgets updated if needed
- [ ] Fail-safe behaviors implemented
- [ ] Recovery procedures documented

## Leadership Verification
- [ ] Team leadership has tested/verified functionality

## Pre-merge Checklist
- [ ] Code reviewed by leader
- [ ] (Optional) Changes tested across multiple matches
- [ ] No merge conflicts with production
- [ ] CI/CD pipeline passing
- [ ] Branch up to date with production

## Documentation
- [ ] Full Javadoc comments on all classes and variables
- [ ] Complete mkdocs documentation added/updated
- [ ] Update driver documentation
- [ ] Update prematch checklist if needed
- [ ] Update mechanism troubleshooting guide
- [ ] Notify relevant team members
- [ ] Schedule driver practice with changes
