### PR TITLE
Add velocity limit near elevator limits

### DIFF
--- a/src/main/java/frc/alotobots/reefscape/subsystems/elevator/ElevatorSubsystem.java
+++ b/src/main/java/frc/alotobots/reefscape/subsystems/elevator/ElevatorSubsystem.java
@@ -13,7 +13,6 @@
 package frc.alotobots.reefscape.subsystems.elevator;
 
 import static edu.wpi.first.units.Units.*;
-import static frc.alotobots.reefscape.subsystems.elevator.constants.ElevatorConstants.*;
 import static frc.alotobots.reefscape.subsystems.elevator.constants.ElevatorConstants.Limits.*;
 import static frc.alotobots.reefscape.subsystems.elevator.constants.ElevatorConstants.Thresholds.AT_SET_POINT_POSITION_THRESHOLD;
 import static frc.alotobots.reefscape.subsystems.elevator.constants.ElevatorConstants.Thresholds.AT_SET_POINT_TIME_THRESHOLD;
@@ -87,7 +86,7 @@ public class ElevatorSubsystem extends SubsystemBase {
    * Controls the elevator to move to a specified velocity using closed-loop velocity control.
    *
    * @param velocity Target velocity in meters per second, automatically constrained between
-   *     -MAX_VELOCITY and MAX_VELOCITY
+   *     -MAX_OPERATOR_VELOCITY and MAX_OPERATOR_VELOCITY
    */
   public void runToTargetVelocity(LinearVelocity velocity) {
     LinearVelocity adjustedVelocity = applyVelocityLimitIfNeeded(velocity);
@@ -180,8 +179,8 @@ public class ElevatorSubsystem extends SubsystemBase {
       return MetersPerSecond.of(
           MathUtil.clamp(
               velocity.in(MetersPerSecond),
-              -MAX_VELOCITY.in(MetersPerSecond),
-              MAX_VELOCITY.in(MetersPerSecond)));
+              -MAX_OPERATOR_VELOCITY.in(MetersPerSecond),
+              MAX_OPERATOR_VELOCITY.in(MetersPerSecond)));
     }
   }
 }

--- a/src/main/java/frc/alotobots/reefscape/subsystems/elevator/ElevatorSubsystem.java
+++ b/src/main/java/frc/alotobots/reefscape/subsystems/elevator/ElevatorSubsystem.java
@@ -79,7 +79,7 @@ public class ElevatorSubsystem extends SubsystemBase {
     Distance adjustedHeight =
         Meters.of(MathUtil.clamp(height.in(Meters), MIN_HEIGHT.in(Meters), MAX_HEIGHT.in(Meters)));
     targetHeight = adjustedHeight;
-    io.setElevatorPosition(adjustedHeight, ControlType.ClosedLoop.POSITION.ordinal());
+    io.setElevatorPositionMotionMagic(adjustedHeight, ControlType.ClosedLoop.POSITION.ordinal());
     Logger.recordOutput("Elevator/ControlType", ControlType.ClosedLoop.POSITION);
   }
 

--- a/src/main/java/frc/alotobots/reefscape/subsystems/elevator/ElevatorSubsystem.java
+++ b/src/main/java/frc/alotobots/reefscape/subsystems/elevator/ElevatorSubsystem.java
@@ -90,12 +90,7 @@ public class ElevatorSubsystem extends SubsystemBase {
    *     -MAX_SPEED and MAX_SPEED
    */
   public void runToTargetVelocity(LinearVelocity velocity) {
-    LinearVelocity adjustedVelocity =
-        MetersPerSecond.of(
-            MathUtil.clamp(
-                velocity.in(MetersPerSecond),
-                -MAX_SPEED.in(MetersPerSecond),
-                MAX_SPEED.in(MetersPerSecond)));
+    LinearVelocity adjustedVelocity = applyVelocityLimitIfNeeded(velocity);
     io.setElevatorVelocity(adjustedVelocity, ControlType.ClosedLoop.VELOCITY.ordinal());
     Logger.recordOutput("Elevator/ControlType", ControlType.ClosedLoop.VELOCITY);
   }
@@ -155,5 +150,33 @@ public class ElevatorSubsystem extends SubsystemBase {
       atSetpointTimer.stop();
       return false;
     }
+  }
+
+  /**
+   * Checks if the elevator is within the velocity limit distance from the top or bottom limits.
+   *
+   * @return true if the elevator is within the velocity limit distance, false otherwise
+   */
+  private boolean isVelocityLimitNeeded() {
+    return inputs.leftHeight.minus(MIN_HEIGHT).abs(Meters) < DISTANCE_FROM_LIMIT.in(Meters)
+        || inputs.leftHeight.minus(MAX_HEIGHT).abs(Meters) < DISTANCE_FROM_LIMIT.in(Meters);
+  }
+
+  /**
+   * Applies the velocity limit if the elevator is within the velocity limit distance from the top
+   * or bottom limits.
+   *
+   * @param velocity The target velocity
+   * @return The adjusted velocity if the limit is needed, otherwise the original velocity
+   */
+  private LinearVelocity applyVelocityLimitIfNeeded(LinearVelocity velocity) {
+    if (isVelocityLimitNeeded()) {
+      return MetersPerSecond.of(
+          MathUtil.clamp(
+              velocity.in(MetersPerSecond),
+              -MAX_VELOCITY_NEAR_LIMIT.in(MetersPerSecond),
+              MAX_VELOCITY_NEAR_LIMIT.in(MetersPerSecond)));
+    }
+    return velocity;
   }
 }

--- a/src/main/java/frc/alotobots/reefscape/subsystems/elevator/ElevatorSubsystem.java
+++ b/src/main/java/frc/alotobots/reefscape/subsystems/elevator/ElevatorSubsystem.java
@@ -87,7 +87,7 @@ public class ElevatorSubsystem extends SubsystemBase {
    * Controls the elevator to move to a specified velocity using closed-loop velocity control.
    *
    * @param velocity Target velocity in meters per second, automatically constrained between
-   *     -MAX_SPEED and MAX_SPEED
+   *     -MAX_VELOCITY and MAX_VELOCITY
    */
   public void runToTargetVelocity(LinearVelocity velocity) {
     LinearVelocity adjustedVelocity = applyVelocityLimitIfNeeded(velocity);
@@ -176,7 +176,12 @@ public class ElevatorSubsystem extends SubsystemBase {
               velocity.in(MetersPerSecond),
               -MAX_VELOCITY_NEAR_LIMIT.in(MetersPerSecond),
               MAX_VELOCITY_NEAR_LIMIT.in(MetersPerSecond)));
+    } else {
+      return MetersPerSecond.of(
+          MathUtil.clamp(
+              velocity.in(MetersPerSecond),
+              -MAX_VELOCITY.in(MetersPerSecond),
+              MAX_VELOCITY.in(MetersPerSecond)));
     }
-    return velocity;
   }
 }

--- a/src/main/java/frc/alotobots/reefscape/subsystems/elevator/commands/DefaultElevatorRunAtVelocity.java
+++ b/src/main/java/frc/alotobots/reefscape/subsystems/elevator/commands/DefaultElevatorRunAtVelocity.java
@@ -14,7 +14,7 @@ package frc.alotobots.reefscape.subsystems.elevator.commands;
 
 import static frc.alotobots.OI.AxisLimits.MAX_AXIS_LIMIT;
 import static frc.alotobots.OI.AxisLimits.MIN_AXIS_LIMIT;
-import static frc.alotobots.reefscape.subsystems.elevator.constants.ElevatorConstants.Limits.MAX_VELOCITY;
+import static frc.alotobots.reefscape.subsystems.elevator.constants.ElevatorConstants.Limits.MAX_OPERATOR_VELOCITY;
 
 import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.units.measure.LinearVelocity;
@@ -71,7 +71,7 @@ public class DefaultElevatorRunAtVelocity extends Command {
   @Override
   public void execute() {
     double adjustedInput = MathUtil.clamp(input.getAsDouble(), MIN_AXIS_LIMIT, MAX_AXIS_LIMIT);
-    LinearVelocity velocity = MAX_VELOCITY.times(adjustedInput);
+    LinearVelocity velocity = MAX_OPERATOR_VELOCITY.times(adjustedInput);
     elevatorSubsystem.runToTargetVelocity(velocity);
   }
 

--- a/src/main/java/frc/alotobots/reefscape/subsystems/elevator/commands/DefaultElevatorRunAtVelocity.java
+++ b/src/main/java/frc/alotobots/reefscape/subsystems/elevator/commands/DefaultElevatorRunAtVelocity.java
@@ -14,7 +14,7 @@ package frc.alotobots.reefscape.subsystems.elevator.commands;
 
 import static frc.alotobots.OI.AxisLimits.MAX_AXIS_LIMIT;
 import static frc.alotobots.OI.AxisLimits.MIN_AXIS_LIMIT;
-import static frc.alotobots.reefscape.subsystems.elevator.constants.ElevatorConstants.Limits.MAX_SPEED;
+import static frc.alotobots.reefscape.subsystems.elevator.constants.ElevatorConstants.Limits.MAX_VELOCITY;
 
 import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.units.measure.LinearVelocity;
@@ -71,7 +71,7 @@ public class DefaultElevatorRunAtVelocity extends Command {
   @Override
   public void execute() {
     double adjustedInput = MathUtil.clamp(input.getAsDouble(), MIN_AXIS_LIMIT, MAX_AXIS_LIMIT);
-    LinearVelocity velocity = MAX_SPEED.times(adjustedInput);
+    LinearVelocity velocity = MAX_VELOCITY.times(adjustedInput);
     elevatorSubsystem.runToTargetVelocity(velocity);
   }
 

--- a/src/main/java/frc/alotobots/reefscape/subsystems/elevator/constants/ElevatorConstants.java
+++ b/src/main/java/frc/alotobots/reefscape/subsystems/elevator/constants/ElevatorConstants.java
@@ -38,7 +38,7 @@ public final class ElevatorConstants {
     public static final Distance MAX_HEIGHT = Meters.of(1.80);
 
     /** Minimum allowed height */
-    public static final Distance MIN_HEIGHT = Meters.of(0.253311);
+    public static final Distance MIN_HEIGHT = Meters.of(0.23);
 
     /** Maximum open loop percent output */
     public static final double MAX_OPEN_LOOP_PERCENTAGE = 0.5;
@@ -50,16 +50,16 @@ public final class ElevatorConstants {
     public static final boolean LIMITS_ENABLED = true;
 
     /** Maximum velocity near the top or bottom limit */
-    public static final LinearVelocity MAX_VELOCITY_NEAR_LIMIT = MetersPerSecond.of(0.2);
+    public static final LinearVelocity MAX_VELOCITY_NEAR_LIMIT = MetersPerSecond.of(0.1);
 
     /** Distance from the top or bottom limit where the velocity limit applies */
-    public static final Distance DISTANCE_FROM_LIMIT = Meters.of(0.1);
+    public static final Distance DISTANCE_FROM_LIMIT = Meters.of(0.2);
   }
 
   /** Position setpoints for different elevator states */
   public static final class Setpoints {
     /** Height when elevator is fully retracted/stowed */
-    public static final Distance STOWED = Meters.of(0.3);
+    public static final Distance STOWED = Meters.of(0.1);
 
     /** Height for picking up from coral station */
     public static final Distance CORAL_STATION = Meters.of(0.80);

--- a/src/main/java/frc/alotobots/reefscape/subsystems/elevator/constants/ElevatorConstants.java
+++ b/src/main/java/frc/alotobots/reefscape/subsystems/elevator/constants/ElevatorConstants.java
@@ -44,7 +44,7 @@ public final class ElevatorConstants {
     public static final double MAX_OPEN_LOOP_PERCENTAGE = 0.5;
 
     /** Max speed (magnitude) */
-    public static final LinearVelocity MAX_SPEED = MetersPerSecond.of(0.5);
+    public static final LinearVelocity MAX_VELOCITY = MetersPerSecond.of(0.5);
 
     /** Enable Limits */
     public static final boolean LIMITS_ENABLED = true;

--- a/src/main/java/frc/alotobots/reefscape/subsystems/elevator/constants/ElevatorConstants.java
+++ b/src/main/java/frc/alotobots/reefscape/subsystems/elevator/constants/ElevatorConstants.java
@@ -48,6 +48,12 @@ public final class ElevatorConstants {
 
     /** Enable Limits */
     public static final boolean LIMITS_ENABLED = true;
+
+    /** Maximum velocity near the top or bottom limit */
+    public static final LinearVelocity MAX_VELOCITY_NEAR_LIMIT = MetersPerSecond.of(0.2);
+
+    /** Distance from the top or bottom limit where the velocity limit applies */
+    public static final Distance DISTANCE_FROM_LIMIT = Meters.of(0.1);
   }
 
   /** Position setpoints for different elevator states */

--- a/src/main/java/frc/alotobots/reefscape/subsystems/elevator/constants/ElevatorConstants.java
+++ b/src/main/java/frc/alotobots/reefscape/subsystems/elevator/constants/ElevatorConstants.java
@@ -44,7 +44,7 @@ public final class ElevatorConstants {
     public static final double MAX_OPEN_LOOP_PERCENTAGE = 0.5;
 
     /** Max speed (magnitude) */
-    public static final LinearVelocity MAX_VELOCITY = MetersPerSecond.of(0.5);
+    public static final LinearVelocity MAX_OPERATOR_VELOCITY = MetersPerSecond.of(0.5);
 
     /** Enable Limits */
     public static final boolean LIMITS_ENABLED = true;

--- a/src/main/java/frc/alotobots/reefscape/subsystems/elevator/constants/ElevatorTalonFXRealConstants.java
+++ b/src/main/java/frc/alotobots/reefscape/subsystems/elevator/constants/ElevatorTalonFXRealConstants.java
@@ -82,8 +82,8 @@ public final class ElevatorTalonFXRealConstants {
   }
 
   public static final class MotionMagicConstants {
-    public static final LinearVelocity CRUSE_VELOCITY = MetersPerSecond.of(.8);
-    public static final LinearAcceleration ACCELERATION = MetersPerSecondPerSecond.of(.4);
+    public static final LinearVelocity CRUSE_VELOCITY = MetersPerSecond.of(1.0);
+    public static final LinearAcceleration ACCELERATION = MetersPerSecondPerSecond.of(0.8);
     public static final double JERK = 0;
   }
 
@@ -104,4 +104,7 @@ public final class ElevatorTalonFXRealConstants {
 
   /** Neutral mode (brake/coast) setting for the mechanism */
   public static final NeutralModeValue MECHANISM_NEUTRAL_MODE = NeutralModeValue.Brake;
+
+  /** Regression used to calculate height of motor. (Should be linear) Rotations:Meters */
+  public static final double HEIGHT_PER_ROTATION = 0.00977762;
 }

--- a/src/main/java/frc/alotobots/reefscape/subsystems/elevator/constants/ElevatorTalonFXRealConstants.java
+++ b/src/main/java/frc/alotobots/reefscape/subsystems/elevator/constants/ElevatorTalonFXRealConstants.java
@@ -13,10 +13,14 @@
 package frc.alotobots.reefscape.subsystems.elevator.constants;
 
 import static edu.wpi.first.units.Units.Amps;
+import static edu.wpi.first.units.Units.MetersPerSecond;
+import static edu.wpi.first.units.Units.MetersPerSecondPerSecond;
 
 import com.ctre.phoenix6.signals.InvertedValue;
 import com.ctre.phoenix6.signals.NeutralModeValue;
 import edu.wpi.first.units.measure.Current;
+import edu.wpi.first.units.measure.LinearAcceleration;
+import edu.wpi.first.units.measure.LinearVelocity;
 import lombok.experimental.UtilityClass;
 
 /**
@@ -75,6 +79,12 @@ public final class ElevatorTalonFXRealConstants {
       /** Velocity feedforward gain */
       public static final double KV = 0.0;
     }
+  }
+
+  public static final class MotionMagicConstants {
+    public static final LinearVelocity CRUSE_VELOCITY = MetersPerSecond.of(.8);
+    public static final LinearAcceleration ACCELERATION = MetersPerSecondPerSecond.of(.4);
+    public static final double JERK = 0;
   }
 
   /** Contains safety limit constants for the elevator motors. */

--- a/src/main/java/frc/alotobots/reefscape/subsystems/elevator/io/ElevatorIO.java
+++ b/src/main/java/frc/alotobots/reefscape/subsystems/elevator/io/ElevatorIO.java
@@ -14,6 +14,7 @@ package frc.alotobots.reefscape.subsystems.elevator.io;
 
 import static edu.wpi.first.units.Units.*;
 
+import com.ctre.phoenix6.StatusSignal;
 import edu.wpi.first.units.measure.*;
 import org.littletonrobotics.junction.AutoLog;
 
@@ -66,6 +67,13 @@ public interface ElevatorIO {
 
     /** Current velocity of the right elevator motor in meters per second */
     public LinearVelocity rightVelocity = MetersPerSecond.zero();
+
+    /** Current acceleration of the left elevator motor in meters per second per second */
+    public LinearAcceleration leftAcceleration;
+
+    /** Current acceleration of the right elevator motor in meters per second per second */
+    public LinearAcceleration rightAcceleration;
+
 
     /** Applied voltage to the left elevator motor */
     public Voltage leftAppliedVolts = Volts.zero();

--- a/src/main/java/frc/alotobots/reefscape/subsystems/elevator/io/ElevatorIO.java
+++ b/src/main/java/frc/alotobots/reefscape/subsystems/elevator/io/ElevatorIO.java
@@ -96,6 +96,13 @@ public interface ElevatorIO {
   public default void setElevatorPosition(Distance position, int pidSlot) {}
 
   /**
+   * Sets the target position for the elevator using closed-loop control & motion magic.
+   *
+   * @param position The desired position for the elevator
+   */
+  public default void setElevatorPositionMotionMagic(Distance position, int pidSlot) {}
+
+  /**
    * Sets the target velocity for the elevator using closed-loop control.
    *
    * @param velocity The desired velocity for the elevator

--- a/src/main/java/frc/alotobots/reefscape/subsystems/elevator/io/ElevatorIO.java
+++ b/src/main/java/frc/alotobots/reefscape/subsystems/elevator/io/ElevatorIO.java
@@ -69,10 +69,10 @@ public interface ElevatorIO {
     public LinearVelocity rightVelocity = MetersPerSecond.zero();
 
     /** Current acceleration of the left elevator motor in meters per second per second */
-    public LinearAcceleration leftAcceleration;
+    public LinearAcceleration leftAcceleration = MetersPerSecondPerSecond.zero();
 
     /** Current acceleration of the right elevator motor in meters per second per second */
-    public LinearAcceleration rightAcceleration;
+    public LinearAcceleration rightAcceleration = MetersPerSecondPerSecond.zero();
 
 
     /** Applied voltage to the left elevator motor */

--- a/src/main/java/frc/alotobots/reefscape/subsystems/elevator/io/ElevatorIOTalonFXReal.java
+++ b/src/main/java/frc/alotobots/reefscape/subsystems/elevator/io/ElevatorIOTalonFXReal.java
@@ -25,8 +25,7 @@ import static frc.alotobots.Constants.CanId.RIGHT_ELEVATOR_CAN_ID;
 import static frc.alotobots.reefscape.subsystems.elevator.constants.ElevatorConstants.Limits.LIMITS_ENABLED;
 import static frc.alotobots.reefscape.subsystems.elevator.constants.ElevatorConstants.Limits.MAX_HEIGHT;
 import static frc.alotobots.reefscape.subsystems.elevator.constants.ElevatorConstants.Limits.MIN_HEIGHT;
-import static frc.alotobots.reefscape.subsystems.elevator.constants.ElevatorTalonFXRealConstants.LEFT_MOTOR_DIRECTION;
-import static frc.alotobots.reefscape.subsystems.elevator.constants.ElevatorTalonFXRealConstants.MECHANISM_NEUTRAL_MODE;
+import static frc.alotobots.reefscape.subsystems.elevator.constants.ElevatorTalonFXRealConstants.*;
 import static frc.alotobots.reefscape.subsystems.elevator.constants.ElevatorTalonFXRealConstants.MotorSafetyLimits.STATOR_AMP_LIMIT;
 import static frc.alotobots.reefscape.subsystems.elevator.constants.ElevatorTalonFXRealConstants.MotorSafetyLimits.TORQUE_FORWARD_AMP_LIMIT;
 import static frc.alotobots.reefscape.subsystems.elevator.constants.ElevatorTalonFXRealConstants.MotorSafetyLimits.TORQUE_REVERSE_AMP_LIMIT;
@@ -96,6 +95,9 @@ public class ElevatorIOTalonFXReal implements ElevatorIO {
   /** Status signal for the left motor's velocity */
   private final StatusSignal<AngularVelocity> leftVelocity;
 
+  /** Status signal for the left motor's acceleration */
+  private final StatusSignal<AngularAcceleration> leftAcceleration;
+
   /** Status signal for the left motor's position */
   private final StatusSignal<Angle> leftPosition;
 
@@ -107,6 +109,10 @@ public class ElevatorIOTalonFXReal implements ElevatorIO {
 
   /** Status signal for the right motor's velocity */
   private final StatusSignal<AngularVelocity> rightVelocity;
+
+  /** Status signal for the right motor's acceleration */
+  private final StatusSignal<AngularAcceleration> rightAcceleration;
+
 
   /** Status signal for the right motor's position */
   private final StatusSignal<Angle> rightPosition;
@@ -213,6 +219,9 @@ public class ElevatorIOTalonFXReal implements ElevatorIO {
     leftVelocity = leftTalon.getVelocity();
     rightVelocity = rightTalon.getVelocity();
 
+    leftAcceleration = leftTalon.getAcceleration();
+    rightAcceleration = rightTalon.getAcceleration();
+
     leftAppliedVoltage = leftTalon.getMotorVoltage();
     rightAppliedVoltage = rightTalon.getMotorVoltage();
 
@@ -229,6 +238,8 @@ public class ElevatorIOTalonFXReal implements ElevatorIO {
         canRangeDistance,
         leftVelocity,
         rightVelocity,
+        leftAcceleration,
+        rightAcceleration,
         leftAppliedVoltage,
         rightAppliedVoltage,
         leftAppliedCurrent,
@@ -251,13 +262,14 @@ public class ElevatorIOTalonFXReal implements ElevatorIO {
         BaseStatusSignal.refreshAll(
             leftPosition,
             leftVelocity,
+            leftAcceleration,
             leftAppliedVoltage,
             leftAppliedCurrent,
             topSoftLimit,
             bottomSoftLimit);
     var rightSignals =
         BaseStatusSignal.refreshAll(
-            rightPosition, rightVelocity, rightAppliedVoltage, rightAppliedCurrent);
+            rightPosition, rightVelocity, rightAcceleration, rightAppliedVoltage, rightAppliedCurrent);
     var canRangeSignals = BaseStatusSignal.refreshAll(canRangeDistance);
 
     // Current slot
@@ -282,6 +294,10 @@ public class ElevatorIOTalonFXReal implements ElevatorIO {
     // Velocities
     inputs.leftVelocity = talonFXToLinearVelocity(leftVelocity.getValue());
     inputs.rightVelocity = talonFXToLinearVelocity(rightVelocity.getValue());
+
+    // Acceleration
+    inputs.leftAcceleration = talonFXToLinearAcceleration(leftAcceleration.getValue());
+    inputs.rightAcceleration = talonFXToLinearAcceleration(rightAcceleration.getValue());
 
     // Volts
     inputs.leftAppliedVolts = leftAppliedVoltage.getValue();
@@ -355,47 +371,47 @@ public class ElevatorIOTalonFXReal implements ElevatorIO {
 
   /**
    * Converts TalonFX rotations to elevator height. TalonFX reports position in rotations in Phoenix
-   * 6. Uses regression formula y = 0.00942151x + 0.26 where x is rotations and y is meters.
+   * 6. Uses regression formula y = HEIGHT_PER_ROTATION + MIN_HEIGHT where x is rotations and y is meters.
    *
    * @param rotations TalonFX motor rotations
    * @return Height as a Distance unit
    */
   private Distance talonFXToHeight(Angle rotations) {
-    return Meters.of(0.00942151 * rotations.in(Rotations) + MIN_HEIGHT.in(Meters));
+    return Meters.of(HEIGHT_PER_ROTATION * rotations.in(Rotations) + MIN_HEIGHT.in(Meters));
   }
 
   /**
    * Converts TalonFX rotational velocity to linear velocity. TalonFX reports velocity in rotations
-   * per second in Phoenix 6. Uses slope from regression formula y = 0.00942151x + 0.26.
+   * per second in Phoenix 6. Uses slope from regression formula y = HEIGHT_PER_ROTATION + MIN_HEIGHT.
    *
    * @param rotationsPerSecond TalonFX motor rotational velocity
    * @return Linear velocity as a LinearVelocity unit
    */
   private LinearVelocity talonFXToLinearVelocity(AngularVelocity rotationsPerSecond) {
-    return MetersPerSecond.of(rotationsPerSecond.in(RotationsPerSecond) * 0.00942151);
+    return MetersPerSecond.of(rotationsPerSecond.in(RotationsPerSecond) * HEIGHT_PER_ROTATION);
   }
 
   /**
    * Converts elevator height to TalonFX rotations. TalonFX expects position in rotations in Phoenix
-   * 6. Uses inverse of regression formula y = 0.00942151x + 0.26, solving for x: x = (y - 0.26) /
-   * 0.00949501 where y is meters and x is rotations.
+   * 6. Uses inverse of regression formula y = HEIGHT_PER_ROTATION + MIN_HEIGHT, solving for x: x = (y - MIN_HEIGHT) /
+   * HEIGHT_PER_ROTATION where y is meters and x is rotations.
    *
    * @param height Height as a Distance unit
    * @return TalonFX motor rotations as an Angle unit
    */
   private Angle heightToTalonFX(Distance height) {
-    return Rotations.of((height.minus(MIN_HEIGHT).in(Meters)) / 0.00942151);
+    return Rotations.of((height.minus(MIN_HEIGHT).in(Meters)) / HEIGHT_PER_ROTATION);
   }
 
   /**
    * Converts linear velocity to TalonFX rotational velocity. TalonFX expects velocity in rotations
-   * per second in Phoenix 6. Uses inverse slope from regression formula y = 0.00942151x + 0.26.
+   * per second in Phoenix 6. Uses inverse slope from regression formula y = HEIGHT_PER_ROTATION + MIN_HEIGHT.
    *
    * @param linearVelocity Linear velocity as a LinearVelocity unit
    * @return TalonFX motor rotational velocity as an AngularVelocity unit
    */
   private AngularVelocity linearVelocityToTalonFX(LinearVelocity linearVelocity) {
-    return RotationsPerSecond.of(linearVelocity.in(MetersPerSecond) / 0.00942151);
+    return RotationsPerSecond.of(linearVelocity.in(MetersPerSecond) / HEIGHT_PER_ROTATION);
   }
 
   /**
@@ -408,6 +424,19 @@ public class ElevatorIOTalonFXReal implements ElevatorIO {
    */
   private AngularAcceleration linearAccelerationToTalonFX(LinearAcceleration linearAcceleration) {
     return RotationsPerSecondPerSecond.of(
-        linearAcceleration.in(MetersPerSecondPerSecond) / 0.00942151);
+        linearAcceleration.in(MetersPerSecondPerSecond) / HEIGHT_PER_ROTATION);
+  }
+
+  /**
+   * Converts TalonFX rotational acceleration to linear acceleration. TalonFX reports acceleration
+   * in rotations per second squared in Phoenix 6. Uses the same conversion factor as velocity since
+   * acceleration is the time derivative of velocity.
+   *
+   * @param rotationalAcceleration TalonFX motor rotational acceleration as an AngularAcceleration unit
+   * @return Linear acceleration as a LinearAcceleration unit
+   */
+  private LinearAcceleration talonFXToLinearAcceleration(AngularAcceleration rotationalAcceleration) {
+    return MetersPerSecondPerSecond.of(
+        rotationalAcceleration.in(RotationsPerSecondPerSecond) * HEIGHT_PER_ROTATION);
   }
 }

--- a/src/main/java/frc/alotobots/reefscape/subsystems/elevator/io/ElevatorIOTalonFXReal.java
+++ b/src/main/java/frc/alotobots/reefscape/subsystems/elevator/io/ElevatorIOTalonFXReal.java
@@ -12,26 +12,52 @@
 */
 package frc.alotobots.reefscape.subsystems.elevator.io;
 
-import static edu.wpi.first.units.Units.*;
-import static frc.alotobots.Constants.CanId.*;
-import static frc.alotobots.reefscape.subsystems.elevator.constants.ElevatorConstants.Limits.*;
+import static edu.wpi.first.units.Units.Amps;
+import static edu.wpi.first.units.Units.Meters;
+import static edu.wpi.first.units.Units.MetersPerSecond;
+import static edu.wpi.first.units.Units.MetersPerSecondPerSecond;
+import static edu.wpi.first.units.Units.Rotations;
+import static edu.wpi.first.units.Units.RotationsPerSecond;
+import static edu.wpi.first.units.Units.RotationsPerSecondPerSecond;
+import static frc.alotobots.Constants.CanId.ELEVATOR_CANRANGE_ID;
+import static frc.alotobots.Constants.CanId.LEFT_ELEVATOR_CAN_ID;
+import static frc.alotobots.Constants.CanId.RIGHT_ELEVATOR_CAN_ID;
+import static frc.alotobots.reefscape.subsystems.elevator.constants.ElevatorConstants.Limits.LIMITS_ENABLED;
+import static frc.alotobots.reefscape.subsystems.elevator.constants.ElevatorConstants.Limits.MAX_HEIGHT;
+import static frc.alotobots.reefscape.subsystems.elevator.constants.ElevatorConstants.Limits.MIN_HEIGHT;
 import static frc.alotobots.reefscape.subsystems.elevator.constants.ElevatorTalonFXRealConstants.LEFT_MOTOR_DIRECTION;
 import static frc.alotobots.reefscape.subsystems.elevator.constants.ElevatorTalonFXRealConstants.MECHANISM_NEUTRAL_MODE;
-import static frc.alotobots.reefscape.subsystems.elevator.constants.ElevatorTalonFXRealConstants.MotorSafetyLimits.*;
+import static frc.alotobots.reefscape.subsystems.elevator.constants.ElevatorTalonFXRealConstants.MotorSafetyLimits.STATOR_AMP_LIMIT;
+import static frc.alotobots.reefscape.subsystems.elevator.constants.ElevatorTalonFXRealConstants.MotorSafetyLimits.TORQUE_FORWARD_AMP_LIMIT;
+import static frc.alotobots.reefscape.subsystems.elevator.constants.ElevatorTalonFXRealConstants.MotorSafetyLimits.TORQUE_REVERSE_AMP_LIMIT;
 import static frc.alotobots.util.PhoenixUtil.tryUntilOk;
 
 import com.ctre.phoenix6.BaseStatusSignal;
 import com.ctre.phoenix6.StatusSignal;
 import com.ctre.phoenix6.configs.CANrangeConfiguration;
 import com.ctre.phoenix6.configs.TalonFXConfiguration;
-import com.ctre.phoenix6.controls.*;
+import com.ctre.phoenix6.controls.Follower;
+import com.ctre.phoenix6.controls.MotionMagicVoltage;
+import com.ctre.phoenix6.controls.PositionVoltage;
+import com.ctre.phoenix6.controls.VelocityVoltage;
 import com.ctre.phoenix6.hardware.CANrange;
 import com.ctre.phoenix6.hardware.ParentDevice;
 import com.ctre.phoenix6.hardware.TalonFX;
-import com.ctre.phoenix6.signals.*;
+import com.ctre.phoenix6.signals.FeedbackSensorSourceValue;
+import com.ctre.phoenix6.signals.GravityTypeValue;
+import com.ctre.phoenix6.signals.NeutralModeValue;
+import com.ctre.phoenix6.signals.UpdateModeValue;
 import edu.wpi.first.math.filter.Debouncer;
-import edu.wpi.first.units.measure.*;
+import edu.wpi.first.units.measure.Angle;
+import edu.wpi.first.units.measure.AngularAcceleration;
+import edu.wpi.first.units.measure.AngularVelocity;
+import edu.wpi.first.units.measure.Current;
+import edu.wpi.first.units.measure.Distance;
+import edu.wpi.first.units.measure.LinearAcceleration;
+import edu.wpi.first.units.measure.LinearVelocity;
+import edu.wpi.first.units.measure.Voltage;
 import frc.alotobots.reefscape.subsystems.elevator.constants.ElevatorTalonFXRealConstants;
+import frc.alotobots.reefscape.subsystems.elevator.constants.ElevatorTalonFXRealConstants.MotionMagicConstants;
 
 /**
  * Hardware implementation of the Elevator subsystem using TalonFX motors and a CANRange sensor.
@@ -53,16 +79,10 @@ public class ElevatorIOTalonFXReal implements ElevatorIO {
   /** Position voltage control request for standard position-based control */
   private final PositionVoltage positionVoltage = new PositionVoltage(0.0);
 
-  /** Position torque current FOC control request for position control with torque management */
-  private final PositionTorqueCurrentFOC positionTorqueCurrentFOC =
-      new PositionTorqueCurrentFOC(0.0);
+  private final MotionMagicVoltage magicPositionVoltage = new MotionMagicVoltage(0.0);
 
   /** Velocity voltage control request for standard velocity-based control */
   private final VelocityVoltage velocityVoltage = new VelocityVoltage(0.0);
-
-  /** Velocity torque current FOC control request for velocity control with torque management */
-  private final VelocityTorqueCurrentFOC velocityTorqueCurrentFOC =
-      new VelocityTorqueCurrentFOC(0.0);
 
   /** Status signal for the current PID slot */
   private final StatusSignal<Integer> currentPidSlot;
@@ -160,6 +180,13 @@ public class ElevatorIOTalonFXReal implements ElevatorIO {
     leftConfig.CurrentLimits.StatorCurrentLimitEnable = true; // Always should be true
 
     leftConfig.MotorOutput.Inverted = LEFT_MOTOR_DIRECTION;
+
+    leftConfig.MotionMagic.MotionMagicCruiseVelocity =
+        linearVelocityToTalonFX(MotionMagicConstants.CRUSE_VELOCITY).in(RotationsPerSecond);
+    leftConfig.MotionMagic.MotionMagicAcceleration =
+        linearAccelerationToTalonFX(MotionMagicConstants.ACCELERATION)
+            .in(RotationsPerSecondPerSecond);
+    leftConfig.MotionMagic.MotionMagicJerk = MotionMagicConstants.JERK;
 
     // Apply config to left motor
     tryUntilOk(5, () -> leftTalon.getConfigurator().apply(leftConfig, 0.25));
@@ -277,6 +304,18 @@ public class ElevatorIOTalonFXReal implements ElevatorIO {
   }
 
   /**
+   * Sets the elevator to a specific position using closed-loop control.
+   *
+   * @param position The target position as a Distance unit
+   * @param pidSlot The PID slot to use (0 for velocity mode, 1 for position mode)
+   */
+  @Override
+  public void setElevatorPositionMotionMagic(Distance position, int pidSlot) {
+    leftTalon.setControl(
+        magicPositionVoltage.withPosition(heightToTalonFX(position)).withSlot(pidSlot));
+  }
+
+  /**
    * Sets the elevator to a specific velocity using closed-loop control.
    *
    * @param velocity The target velocity as a LinearVelocity unit
@@ -357,5 +396,18 @@ public class ElevatorIOTalonFXReal implements ElevatorIO {
    */
   private AngularVelocity linearVelocityToTalonFX(LinearVelocity linearVelocity) {
     return RotationsPerSecond.of(linearVelocity.in(MetersPerSecond) / 0.00942151);
+  }
+
+  /**
+   * Converts linear acceleration to TalonFX rotational acceleration. TalonFX expects acceleration
+   * in rotations per second squared in Phoenix 6. Uses the same conversion factor as velocity since
+   * acceleration is the time derivative of velocity.
+   *
+   * @param linearAcceleration Linear acceleration as a LinearAcceleration unit
+   * @return TalonFX motor rotational acceleration as an AngularAcceleration unit
+   */
+  private AngularAcceleration linearAccelerationToTalonFX(LinearAcceleration linearAcceleration) {
+    return RotationsPerSecondPerSecond.of(
+        linearAcceleration.in(MetersPerSecondPerSecond) / 0.00942151);
   }
 }

--- a/src/main/java/frc/alotobots/reefscape/subsystems/wrist/WristSubsystem.java
+++ b/src/main/java/frc/alotobots/reefscape/subsystems/wrist/WristSubsystem.java
@@ -72,7 +72,7 @@ public class WristSubsystem extends SubsystemBase {
     Angle adjustedAngle =
         Degrees.of(MathUtil.clamp(angle.in(Degrees), MIN_ANGLE.in(Degrees), MAX_ANGLE.in(Degrees)));
     targetAngle = adjustedAngle;
-    io.setWristPosition(adjustedAngle, ControlType.ClosedLoop.POSITION.ordinal());
+    io.setWristPositionMotionMagic(adjustedAngle, ControlType.ClosedLoop.POSITION.ordinal());
     Logger.recordOutput("Wrist/ControlType", ControlType.ClosedLoop.POSITION);
   }
 

--- a/src/main/java/frc/alotobots/reefscape/subsystems/wrist/constants/WristTalonFXRealConstants.java
+++ b/src/main/java/frc/alotobots/reefscape/subsystems/wrist/constants/WristTalonFXRealConstants.java
@@ -13,17 +13,13 @@
 package frc.alotobots.reefscape.subsystems.wrist.constants;
 
 import static edu.wpi.first.units.Units.Amps;
-import static edu.wpi.first.units.Units.DegreesPerSecond;
-import static edu.wpi.first.units.Units.DegreesPerSecondPerSecond;
-import static edu.wpi.first.units.Units.MetersPerSecond;
+import static edu.wpi.first.units.Units.RotationsPerSecond;
+import static edu.wpi.first.units.Units.RotationsPerSecondPerSecond;
 
-import com.ctre.phoenix6.configs.MotionMagicConfigs;
 import com.ctre.phoenix6.signals.InvertedValue;
 import com.ctre.phoenix6.signals.NeutralModeValue;
 import com.ctre.phoenix6.signals.SensorDirectionValue;
-
 import edu.wpi.first.units.measure.AngularAcceleration;
-import edu.wpi.first.units.measure.AngularMomentum;
 import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.units.measure.Current;
 import lombok.experimental.UtilityClass;
@@ -87,9 +83,9 @@ public class WristTalonFXRealConstants {
   }
 
   public static final class MotionMagicConstants {
-    public static final AngularVelocity CRUSE_VELOCITY = DegreesPerSecond.of(5);
-    public static final AngularAcceleration ACCELERATION = DegreesPerSecondPerSecond.of(2);
-    public static final double JERK = 1;
+    public static final AngularVelocity CRUSE_VELOCITY = RotationsPerSecond.of(.5);
+    public static final AngularAcceleration ACCELERATION = RotationsPerSecondPerSecond.of(.1);
+    public static final double JERK = 0;
   }
 
   /** Contains safety limit constants for the wrist motors. */

--- a/src/main/java/frc/alotobots/reefscape/subsystems/wrist/constants/WristTalonFXRealConstants.java
+++ b/src/main/java/frc/alotobots/reefscape/subsystems/wrist/constants/WristTalonFXRealConstants.java
@@ -13,10 +13,18 @@
 package frc.alotobots.reefscape.subsystems.wrist.constants;
 
 import static edu.wpi.first.units.Units.Amps;
+import static edu.wpi.first.units.Units.DegreesPerSecond;
+import static edu.wpi.first.units.Units.DegreesPerSecondPerSecond;
+import static edu.wpi.first.units.Units.MetersPerSecond;
 
+import com.ctre.phoenix6.configs.MotionMagicConfigs;
 import com.ctre.phoenix6.signals.InvertedValue;
 import com.ctre.phoenix6.signals.NeutralModeValue;
 import com.ctre.phoenix6.signals.SensorDirectionValue;
+
+import edu.wpi.first.units.measure.AngularAcceleration;
+import edu.wpi.first.units.measure.AngularMomentum;
+import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.units.measure.Current;
 import lombok.experimental.UtilityClass;
 
@@ -76,6 +84,12 @@ public class WristTalonFXRealConstants {
       /** Velocity feedforward gain */
       public static final double KV = 0.0;
     }
+  }
+
+  public static final class MotionMagicConstants {
+    public static final AngularVelocity CRUSE_VELOCITY = DegreesPerSecond.of(5);
+    public static final AngularAcceleration ACCELERATION = DegreesPerSecondPerSecond.of(2);
+    public static final double JERK = 1;
   }
 
   /** Contains safety limit constants for the wrist motors. */

--- a/src/main/java/frc/alotobots/reefscape/subsystems/wrist/io/WristIO.java
+++ b/src/main/java/frc/alotobots/reefscape/subsystems/wrist/io/WristIO.java
@@ -89,7 +89,8 @@ public interface WristIO {
    * @param velocity The target velocity to move at
    * @param pidSlot The PID slot to use (0 for velocity, 1 for position)
    */
-  public default void setWristVelocityMotionMagic(AngularVelocity velocity, int pidSlot) {}
+  public default void setWristPositionMotionMagic(Angle position, int pidSlot) {}
+
   /**
    * Runs the wrist using direct percentage output (open-loop control).
    *

--- a/src/main/java/frc/alotobots/reefscape/subsystems/wrist/io/WristIO.java
+++ b/src/main/java/frc/alotobots/reefscape/subsystems/wrist/io/WristIO.java
@@ -15,6 +15,7 @@ package frc.alotobots.reefscape.subsystems.wrist.io;
 import static edu.wpi.first.units.Units.*;
 
 import edu.wpi.first.units.measure.Angle;
+import edu.wpi.first.units.measure.AngularAcceleration;
 import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.units.measure.Current;
 import edu.wpi.first.units.measure.Voltage;
@@ -50,6 +51,8 @@ public interface WristIO {
     /** Current angular velocity of the wrist */
     public AngularVelocity rotationVelocity = RotationsPerSecond.zero();
 
+    public AngularAcceleration rotationAcceleration = RotationsPerSecondPerSecond.zero();
+
     /** Current voltage being applied to the motor */
     public Voltage motorAppliedVolts = Volts.zero();
 
@@ -80,6 +83,13 @@ public interface WristIO {
    */
   public default void setWristVelocity(AngularVelocity velocity, int pidSlot) {}
 
+  /**
+   * Sets the wrist to run at a target velocity using closed-loop control.
+   *
+   * @param velocity The target velocity to move at
+   * @param pidSlot The PID slot to use (0 for velocity, 1 for position)
+   */
+  public default void setWristVelocityMotionMagic(AngularVelocity velocity, int pidSlot) {}
   /**
    * Runs the wrist using direct percentage output (open-loop control).
    *

--- a/src/main/java/frc/alotobots/reefscape/subsystems/wrist/io/WristIOTalonFXReal.java
+++ b/src/main/java/frc/alotobots/reefscape/subsystems/wrist/io/WristIOTalonFXReal.java
@@ -27,12 +27,9 @@ import com.ctre.phoenix6.BaseStatusSignal;
 import com.ctre.phoenix6.StatusSignal;
 import com.ctre.phoenix6.configs.CANcoderConfiguration;
 import com.ctre.phoenix6.configs.TalonFXConfiguration;
-import com.ctre.phoenix6.controls.MotionMagicVelocityTorqueCurrentFOC;
-import com.ctre.phoenix6.controls.MotionMagicVelocityVoltage;
 import com.ctre.phoenix6.controls.MotionMagicVoltage;
 import com.ctre.phoenix6.controls.PositionTorqueCurrentFOC;
 import com.ctre.phoenix6.controls.PositionVoltage;
-import com.ctre.phoenix6.controls.VelocityTorqueCurrentFOC;
 import com.ctre.phoenix6.controls.VelocityVoltage;
 import com.ctre.phoenix6.hardware.CANcoder;
 import com.ctre.phoenix6.hardware.ParentDevice;
@@ -65,15 +62,11 @@ public class WristIOTalonFXReal implements WristIO {
 
   /** Control mode for position control using direct voltage */
   private final PositionVoltage positionVoltage = new PositionVoltage(0);
-  private final MotionMagicVoltage magicPositionVoltage = new MotionMagicVoltage(0);
 
-  /** Control mode for velocity control using torque-based Field-Oriented Control */
-  private final VelocityTorqueCurrentFOC velocityTorqueCurrentFOC = new VelocityTorqueCurrentFOC(0);
-  private final MotionMagicVelocityTorqueCurrentFOC magicVelocityTorqueCurrentFOC = new MotionMagicVelocityTorqueCurrentFOC(0);
+  private final MotionMagicVoltage magicPositionVoltage = new MotionMagicVoltage(0);
 
   /** Control mode for velocity control using direct voltage */
   private final VelocityVoltage velocityVoltage = new VelocityVoltage(0);
-  private final MotionMagicVelocityVoltage magicVelocityVoltage = new MotionMagicVelocityVoltage(0);
 
   // Status Signals for monitoring hardware state
   /** Current active PID slot being used for control */
@@ -87,6 +80,7 @@ public class WristIOTalonFXReal implements WristIO {
 
   /** Current angular velocity of the wrist */
   StatusSignal<AngularVelocity> wristVelocity;
+
   StatusSignal<AngularAcceleration> wristAcceleration;
 
   /** Current angular position of the wrist */
@@ -154,11 +148,11 @@ public class WristIOTalonFXReal implements WristIO {
 
     wristMotorConfig.MotorOutput.Inverted = MOTOR_DIRECTION;
 
-    var wristMotionMagicConstants = wristMotorConfig.MotionMagic;
-
-    wristMotionMagicConstants.MotionMagicCruiseVelocity = MotionMagicConstants.CRUSE_VELOCITY.in(RotationsPerSecond);
-    wristMotionMagicConstants.MotionMagicAcceleration = MotionMagicConstants.ACCELERATION.in(RotationsPerSecondPerSecond);
-    wristMotionMagicConstants.MotionMagicJerk = MotionMagicConstants.JERK;
+    wristMotorConfig.MotionMagic.MotionMagicCruiseVelocity =
+        MotionMagicConstants.CRUSE_VELOCITY.in(RotationsPerSecond);
+    wristMotorConfig.MotionMagic.MotionMagicAcceleration =
+        MotionMagicConstants.ACCELERATION.in(RotationsPerSecondPerSecond);
+    wristMotorConfig.MotionMagic.MotionMagicJerk = MotionMagicConstants.JERK;
 
     tryUntilOk(5, () -> wristTalon.getConfigurator().apply(wristMotorConfig, 0.25));
 
@@ -226,6 +220,28 @@ public class WristIOTalonFXReal implements WristIO {
   }
 
   /**
+   * Sets the wrist to a target position using closed-loop control.
+   *
+   * @param rotation The target angle to move to
+   * @param pidSlot The PID slot to use (0 for velocity, 1 for position)
+   */
+  @Override
+  public void setWristPosition(Angle rotation, int pidSlot) {
+    wristTalon.setControl(positionVoltage.withPosition(rotation).withSlot(pidSlot));
+  }
+
+  /**
+   * Sets the wrist to a target position using closed-loop control & motion magic.
+   *
+   * @param rotation The target angle to move to
+   * @param pidSlot The PID slot to use (0 for velocity, 1 for position)
+   */
+  @Override
+  public void setWristPositionMotionMagic(Angle rotation, int pidSlot) {
+    wristTalon.setControl(positionVoltage.withPosition(rotation).withSlot(pidSlot));
+  }
+
+  /**
    * Sets the wrist to run at a target velocity using closed-loop control.
    *
    * @param velocity The target velocity to move at
@@ -234,18 +250,6 @@ public class WristIOTalonFXReal implements WristIO {
   @Override
   public void setWristVelocity(AngularVelocity velocity, int pidSlot) {
     wristTalon.setControl(velocityVoltage.withVelocity(velocity).withSlot(pidSlot));
-  }
-
-
-  /**
-   * Sets the wrist to run at a target velocity using closed-loop control & motion magic.
-   *
-   * @param velocity The target velocity to move at
-   * @param pidSlot The PID slot to use (0 for velocity, 1 for position)
-   */
-  @Override
-  public void setWristVelocityMotionMagic(AngularVelocity velocity, int pidSlot) {
-    wristTalon.setControl(magicVelocityVoltage.withVelocity(velocity).withSlot(pidSlot));
   }
 
   /**

--- a/src/main/java/frc/alotobots/reefscape/subsystems/wrist/io/WristIOTalonFXReal.java
+++ b/src/main/java/frc/alotobots/reefscape/subsystems/wrist/io/WristIOTalonFXReal.java
@@ -14,6 +14,8 @@ package frc.alotobots.reefscape.subsystems.wrist.io;
 
 import static edu.wpi.first.units.Units.Amps;
 import static edu.wpi.first.units.Units.Rotations;
+import static edu.wpi.first.units.Units.RotationsPerSecond;
+import static edu.wpi.first.units.Units.RotationsPerSecondPerSecond;
 import static frc.alotobots.Constants.CanId.WRIST_ENCODER_CAN_ID;
 import static frc.alotobots.Constants.CanId.WRIST_MOTOR_CAN_ID;
 import static frc.alotobots.reefscape.subsystems.wrist.constants.WristConstants.Limits.*;
@@ -25,6 +27,9 @@ import com.ctre.phoenix6.BaseStatusSignal;
 import com.ctre.phoenix6.StatusSignal;
 import com.ctre.phoenix6.configs.CANcoderConfiguration;
 import com.ctre.phoenix6.configs.TalonFXConfiguration;
+import com.ctre.phoenix6.controls.MotionMagicVelocityTorqueCurrentFOC;
+import com.ctre.phoenix6.controls.MotionMagicVelocityVoltage;
+import com.ctre.phoenix6.controls.MotionMagicVoltage;
 import com.ctre.phoenix6.controls.PositionTorqueCurrentFOC;
 import com.ctre.phoenix6.controls.PositionVoltage;
 import com.ctre.phoenix6.controls.VelocityTorqueCurrentFOC;
@@ -36,6 +41,7 @@ import com.ctre.phoenix6.signals.FeedbackSensorSourceValue;
 import com.ctre.phoenix6.signals.GravityTypeValue;
 import edu.wpi.first.math.filter.Debouncer;
 import edu.wpi.first.units.measure.Angle;
+import edu.wpi.first.units.measure.AngularAcceleration;
 import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.units.measure.Current;
 import edu.wpi.first.units.measure.Voltage;
@@ -59,12 +65,15 @@ public class WristIOTalonFXReal implements WristIO {
 
   /** Control mode for position control using direct voltage */
   private final PositionVoltage positionVoltage = new PositionVoltage(0);
+  private final MotionMagicVoltage magicPositionVoltage = new MotionMagicVoltage(0);
 
   /** Control mode for velocity control using torque-based Field-Oriented Control */
   private final VelocityTorqueCurrentFOC velocityTorqueCurrentFOC = new VelocityTorqueCurrentFOC(0);
+  private final MotionMagicVelocityTorqueCurrentFOC magicVelocityTorqueCurrentFOC = new MotionMagicVelocityTorqueCurrentFOC(0);
 
   /** Control mode for velocity control using direct voltage */
   private final VelocityVoltage velocityVoltage = new VelocityVoltage(0);
+  private final MotionMagicVelocityVoltage magicVelocityVoltage = new MotionMagicVelocityVoltage(0);
 
   // Status Signals for monitoring hardware state
   /** Current active PID slot being used for control */
@@ -78,6 +87,7 @@ public class WristIOTalonFXReal implements WristIO {
 
   /** Current angular velocity of the wrist */
   StatusSignal<AngularVelocity> wristVelocity;
+  StatusSignal<AngularAcceleration> wristAcceleration;
 
   /** Current angular position of the wrist */
   StatusSignal<Angle> wristPosition;
@@ -144,6 +154,12 @@ public class WristIOTalonFXReal implements WristIO {
 
     wristMotorConfig.MotorOutput.Inverted = MOTOR_DIRECTION;
 
+    var wristMotionMagicConstants = wristMotorConfig.MotionMagic;
+
+    wristMotionMagicConstants.MotionMagicCruiseVelocity = MotionMagicConstants.CRUSE_VELOCITY.in(RotationsPerSecond);
+    wristMotionMagicConstants.MotionMagicAcceleration = MotionMagicConstants.ACCELERATION.in(RotationsPerSecondPerSecond);
+    wristMotionMagicConstants.MotionMagicJerk = MotionMagicConstants.JERK;
+
     tryUntilOk(5, () -> wristTalon.getConfigurator().apply(wristMotorConfig, 0.25));
 
     var wristEncoderConfig = new CANcoderConfiguration();
@@ -158,6 +174,7 @@ public class WristIOTalonFXReal implements WristIO {
     wristAppliedVoltage = wristTalon.getMotorVoltage();
     wristAppliedCurrent = wristTalon.getStatorCurrent();
     wristVelocity = wristTalon.getVelocity();
+    wristAcceleration = wristTalon.getAcceleration();
     wristPosition = wristTalon.getPosition();
     topSoftLimit = wristTalon.getFault_ForwardSoftLimit();
     bottomSoftLimit = wristTalon.getFault_ReverseSoftLimit();
@@ -168,6 +185,7 @@ public class WristIOTalonFXReal implements WristIO {
         wristAppliedVoltage,
         wristAppliedCurrent,
         wristVelocity,
+        wristAcceleration,
         wristPosition,
         topSoftLimit,
         bottomSoftLimit);
@@ -208,17 +226,6 @@ public class WristIOTalonFXReal implements WristIO {
   }
 
   /**
-   * Sets the wrist to a target position using closed-loop control.
-   *
-   * @param rotation The target angle to move to
-   * @param pidSlot The PID slot to use (0 for velocity, 1 for position)
-   */
-  @Override
-  public void setWristPosition(Angle rotation, int pidSlot) {
-    wristTalon.setControl(positionVoltage.withPosition(rotation).withSlot(pidSlot));
-  }
-
-  /**
    * Sets the wrist to run at a target velocity using closed-loop control.
    *
    * @param velocity The target velocity to move at
@@ -227,6 +234,18 @@ public class WristIOTalonFXReal implements WristIO {
   @Override
   public void setWristVelocity(AngularVelocity velocity, int pidSlot) {
     wristTalon.setControl(velocityVoltage.withVelocity(velocity).withSlot(pidSlot));
+  }
+
+
+  /**
+   * Sets the wrist to run at a target velocity using closed-loop control & motion magic.
+   *
+   * @param velocity The target velocity to move at
+   * @param pidSlot The PID slot to use (0 for velocity, 1 for position)
+   */
+  @Override
+  public void setWristVelocityMotionMagic(AngularVelocity velocity, int pidSlot) {
+    wristTalon.setControl(magicVelocityVoltage.withVelocity(velocity).withSlot(pidSlot));
   }
 
   /**


### PR DESCRIPTION
Implement a velocity limit when within a specified distance from the top and bottom limits of the elevator.

* Add `MAX_VELOCITY_NEAR_LIMIT` and `DISTANCE_FROM_LIMIT` constants to `ElevatorConstants`.
* Update `runToTargetVelocity` method in `ElevatorSubsystem` to apply velocity limit if needed.
* Add `isVelocityLimitNeeded` method to check proximity to top/bottom limits in `ElevatorSubsystem`.
* Add `applyVelocityLimitIfNeeded` method to adjust velocity based on proximity to limits in `ElevatorSubsystem`.

