### PR TITLE
Add climbing elevator PID mode

### DIFF
--- a/src/main/java/frc/alotobots/RobotContainer.java
+++ b/src/main/java/frc/alotobots/RobotContainer.java
@@ -47,6 +47,7 @@ import frc.alotobots.reefscape.subsystems.coralIntake.commands.CoralIntakeIntake
 import frc.alotobots.reefscape.subsystems.coralIntake.io.CoralIntakeIO;
 import frc.alotobots.reefscape.subsystems.coralIntake.io.CoralIntakeIOVortexReal;
 import frc.alotobots.reefscape.subsystems.elevator.ElevatorSubsystem;
+import frc.alotobots.reefscape.subsystems.elevator.commands.ClimbingElevatorRunAtVelocity;
 import frc.alotobots.reefscape.subsystems.elevator.commands.DefaultElevatorRunAtVelocity;
 import frc.alotobots.reefscape.subsystems.elevator.commands.ElevatorRunToHeight;
 import frc.alotobots.reefscape.subsystems.elevator.constants.ElevatorConstants;
@@ -272,7 +273,9 @@ public class RobotContainer {
     wristGroundButton.toggleOnTrue(
         new WristRunToAngle(wristSubsystem, WristConstants.Setpoints.GROUND_INTAKE));
 
-    climbButton.onTrue(new Climb(climberSubsystem, elevatorSubsystem));
+    climbButton.toggleOnTrue(
+        new Climb(climberSubsystem, elevatorSubsystem).alongWith(
+            new ClimbingElevatorRunAtVelocity(elevatorSubsystem, () -> -getElevatorAxis())));
     unClimbButton.onTrue(new UnClimb(climberSubsystem));
   }
 

--- a/src/main/java/frc/alotobots/RobotContainer.java
+++ b/src/main/java/frc/alotobots/RobotContainer.java
@@ -20,7 +20,6 @@ import com.pathplanner.lib.auto.AutoBuilder;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.wpilibj2.command.Command;
-import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine;
 import frc.alotobots.library.subsystems.swervedrive.*;
 import frc.alotobots.library.subsystems.swervedrive.commands.*;
@@ -37,10 +36,10 @@ import frc.alotobots.library.subsystems.vision.photonvision.apriltag.util.AprilT
 import frc.alotobots.library.subsystems.vision.photonvision.objectdetection.ObjectDetectionSubsystem;
 import frc.alotobots.library.subsystems.vision.photonvision.objectdetection.constants.ObjectDetectionConstants;
 import frc.alotobots.library.subsystems.vision.photonvision.objectdetection.io.*;
-import frc.alotobots.reefscape.commands.states.*;
-import frc.alotobots.reefscape.subsystems.climber.ClimberSubsystem;
 import frc.alotobots.reefscape.commands.groups.Climb;
 import frc.alotobots.reefscape.commands.groups.UnClimb;
+import frc.alotobots.reefscape.commands.states.*;
+import frc.alotobots.reefscape.subsystems.climber.ClimberSubsystem;
 import frc.alotobots.reefscape.subsystems.climber.commands.ClimberDisableServos;
 import frc.alotobots.reefscape.subsystems.climber.io.ClimberIORevServoReal;
 import frc.alotobots.reefscape.subsystems.coralIntake.CoralIntakeSubsystem;
@@ -49,7 +48,6 @@ import frc.alotobots.reefscape.subsystems.coralIntake.commands.CoralIntakeIntake
 import frc.alotobots.reefscape.subsystems.coralIntake.io.CoralIntakeIO;
 import frc.alotobots.reefscape.subsystems.coralIntake.io.CoralIntakeIOVortexReal;
 import frc.alotobots.reefscape.subsystems.elevator.ElevatorSubsystem;
-import frc.alotobots.reefscape.subsystems.elevator.commands.ElevatorRunAtClimbVelocity;
 import frc.alotobots.reefscape.subsystems.elevator.commands.DefaultElevatorRunAtVelocity;
 import frc.alotobots.reefscape.subsystems.elevator.commands.ElevatorRunToHeight;
 import frc.alotobots.reefscape.subsystems.elevator.constants.ElevatorConstants;

--- a/src/main/java/frc/alotobots/RobotContainer.java
+++ b/src/main/java/frc/alotobots/RobotContainer.java
@@ -20,6 +20,7 @@ import com.pathplanner.lib.auto.AutoBuilder;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine;
 import frc.alotobots.library.subsystems.swervedrive.*;
 import frc.alotobots.library.subsystems.swervedrive.commands.*;
@@ -38,8 +39,9 @@ import frc.alotobots.library.subsystems.vision.photonvision.objectdetection.cons
 import frc.alotobots.library.subsystems.vision.photonvision.objectdetection.io.*;
 import frc.alotobots.reefscape.commands.states.*;
 import frc.alotobots.reefscape.subsystems.climber.ClimberSubsystem;
-import frc.alotobots.reefscape.subsystems.climber.commands.Climb;
-import frc.alotobots.reefscape.subsystems.climber.commands.UnClimb;
+import frc.alotobots.reefscape.commands.groups.Climb;
+import frc.alotobots.reefscape.commands.groups.UnClimb;
+import frc.alotobots.reefscape.subsystems.climber.commands.ClimberDisableServos;
 import frc.alotobots.reefscape.subsystems.climber.io.ClimberIORevServoReal;
 import frc.alotobots.reefscape.subsystems.coralIntake.CoralIntakeSubsystem;
 import frc.alotobots.reefscape.subsystems.coralIntake.commands.CoralIntakeEjectThrough;
@@ -47,7 +49,7 @@ import frc.alotobots.reefscape.subsystems.coralIntake.commands.CoralIntakeIntake
 import frc.alotobots.reefscape.subsystems.coralIntake.io.CoralIntakeIO;
 import frc.alotobots.reefscape.subsystems.coralIntake.io.CoralIntakeIOVortexReal;
 import frc.alotobots.reefscape.subsystems.elevator.ElevatorSubsystem;
-import frc.alotobots.reefscape.subsystems.elevator.commands.ClimbingElevatorRunAtVelocity;
+import frc.alotobots.reefscape.subsystems.elevator.commands.ElevatorRunAtClimbVelocity;
 import frc.alotobots.reefscape.subsystems.elevator.commands.DefaultElevatorRunAtVelocity;
 import frc.alotobots.reefscape.subsystems.elevator.commands.ElevatorRunToHeight;
 import frc.alotobots.reefscape.subsystems.elevator.constants.ElevatorConstants;
@@ -228,6 +230,7 @@ public class RobotContainer {
         new DefaultWristRunAtVelocity(wristSubsystem, OI::getWristAxis));
     // blingSubsystem.setDefaultCommand(
     //    new NoAllianceWaiting(blingSubsystem).andThen(new SetToAllianceColor(blingSubsystem)));
+    climberSubsystem.setDefaultCommand(new ClimberDisableServos(climberSubsystem));
   }
 
   /** Contains button based commands */
@@ -274,8 +277,7 @@ public class RobotContainer {
         new WristRunToAngle(wristSubsystem, WristConstants.Setpoints.GROUND_INTAKE));
 
     climbButton.toggleOnTrue(
-        new Climb(climberSubsystem, elevatorSubsystem).alongWith(
-            new ClimbingElevatorRunAtVelocity(elevatorSubsystem, () -> -getElevatorAxis())));
+        new Climb(climberSubsystem, elevatorSubsystem, () -> -getElevatorAxis()));
     unClimbButton.onTrue(new UnClimb(climberSubsystem));
   }
 

--- a/src/main/java/frc/alotobots/reefscape/commands/groups/Climb.java
+++ b/src/main/java/frc/alotobots/reefscape/commands/groups/Climb.java
@@ -10,31 +10,33 @@
 *
 * Source code must be publicly available on GitHub or an alternative web accessible site
 */
-package frc.alotobots.reefscape.subsystems.climber.commands;
+package frc.alotobots.reefscape.commands.groups;
 
 import static edu.wpi.first.units.Units.Meters;
 
 import edu.wpi.first.wpilibj2.command.*;
 import frc.alotobots.reefscape.subsystems.climber.ClimberSubsystem;
 import frc.alotobots.reefscape.subsystems.elevator.ElevatorSubsystem;
+import frc.alotobots.reefscape.subsystems.elevator.commands.ElevatorRunAtClimbVelocity;
 import frc.alotobots.reefscape.subsystems.elevator.commands.ElevatorRunToHeight;
+import frc.alotobots.reefscape.subsystems.elevator.constants.ElevatorConstants;
+
+import java.util.function.DoubleSupplier;
 
 public class Climb extends SequentialCommandGroup {
 
-  public Climb(ClimberSubsystem climberSubsystem, ElevatorSubsystem elevatorSubsystem) {
+  public Climb(ClimberSubsystem climberSubsystem, ElevatorSubsystem elevatorSubsystem, DoubleSupplier input) {
 
     addCommands(
         new InstantCommand(climberSubsystem::enableServos),
-        new ElevatorRunToHeight(elevatorSubsystem, Meters.of(0.8)),
+        new ElevatorRunToHeight(elevatorSubsystem, ElevatorConstants.Setpoints.CLIMB),
         new InstantCommand(climberSubsystem::setPlungerToReceive),
         new InstantCommand(climberSubsystem::unlockCage),
         new WaitUntilCommand(climberSubsystem::getCageSwitches),
         new InstantCommand(climberSubsystem::lockCage),
         new InstantCommand(climberSubsystem::setPlungerToPlunge),
-        new WaitCommand(1),
-        new InstantCommand(climberSubsystem::disableServos)
-        // new ElevatorRunToHeight(elevatorSubsystem, MIN_HEIGHT)
+            new ElevatorRunAtClimbVelocity(elevatorSubsystem, input)
         );
-    addRequirements(climberSubsystem);
+    addRequirements(climberSubsystem, elevatorSubsystem);
   }
 }

--- a/src/main/java/frc/alotobots/reefscape/commands/groups/Climb.java
+++ b/src/main/java/frc/alotobots/reefscape/commands/groups/Climb.java
@@ -12,21 +12,31 @@
 */
 package frc.alotobots.reefscape.commands.groups;
 
-import static edu.wpi.first.units.Units.Meters;
-
 import edu.wpi.first.wpilibj2.command.*;
 import frc.alotobots.reefscape.subsystems.climber.ClimberSubsystem;
 import frc.alotobots.reefscape.subsystems.elevator.ElevatorSubsystem;
 import frc.alotobots.reefscape.subsystems.elevator.commands.ElevatorRunAtClimbVelocity;
 import frc.alotobots.reefscape.subsystems.elevator.commands.ElevatorRunToHeight;
 import frc.alotobots.reefscape.subsystems.elevator.constants.ElevatorConstants;
-
 import java.util.function.DoubleSupplier;
 
+/**
+ * A sequential command group that handles the climbing sequence. This command coordinates the
+ * elevator and climber subsystems to perform a climbing operation.
+ */
 public class Climb extends SequentialCommandGroup {
 
-  public Climb(ClimberSubsystem climberSubsystem, ElevatorSubsystem elevatorSubsystem, DoubleSupplier input) {
-
+  /**
+   * Creates a new Climb command.
+   *
+   * @param climberSubsystem The climber subsystem to control
+   * @param elevatorSubsystem The elevator subsystem to control
+   * @param input The input supplier for controlling climb velocity
+   */
+  public Climb(
+      ClimberSubsystem climberSubsystem,
+      ElevatorSubsystem elevatorSubsystem,
+      DoubleSupplier input) {
     addCommands(
         new InstantCommand(climberSubsystem::enableServos),
         new ElevatorRunToHeight(elevatorSubsystem, ElevatorConstants.Setpoints.CLIMB),
@@ -35,8 +45,7 @@ public class Climb extends SequentialCommandGroup {
         new WaitUntilCommand(climberSubsystem::getCageSwitches),
         new InstantCommand(climberSubsystem::lockCage),
         new InstantCommand(climberSubsystem::setPlungerToPlunge),
-            new ElevatorRunAtClimbVelocity(elevatorSubsystem, input)
-        );
+        new ElevatorRunAtClimbVelocity(elevatorSubsystem, input));
     addRequirements(climberSubsystem, elevatorSubsystem);
   }
 }

--- a/src/main/java/frc/alotobots/reefscape/commands/groups/UnClimb.java
+++ b/src/main/java/frc/alotobots/reefscape/commands/groups/UnClimb.java
@@ -10,7 +10,7 @@
 *
 * Source code must be publicly available on GitHub or an alternative web accessible site
 */
-package frc.alotobots.reefscape.subsystems.climber.commands;
+package frc.alotobots.reefscape.commands.groups;
 
 import edu.wpi.first.wpilibj2.command.*;
 import frc.alotobots.reefscape.subsystems.climber.ClimberSubsystem;
@@ -26,15 +26,10 @@ public class UnClimb extends SequentialCommandGroup {
 
     addCommands(
         new InstantCommand(climberSubsystem::enableServos),
-        // new ElevatorRunToHeight(elevatorSubsystem, Meters.of(0.8)),
         new InstantCommand(climberSubsystem::setPlungerToReceive),
         new InstantCommand(climberSubsystem::unlockCage),
-        // new WaitUntilCommand(climberSubsystem::getCageSwitches),
-        // new InstantCommand(climberSubsystem::lockCage),
-        // new InstantCommand(climberSubsystem::setPlungerToPlunge)
-        new WaitCommand(10),
+        new WaitCommand(1),
         new InstantCommand(climberSubsystem::disableServos)
-        // new ElevatorRunToHeight(elevatorSubsystem, MIN_HEIGHT)
         );
     addRequirements(climberSubsystem);
   }

--- a/src/main/java/frc/alotobots/reefscape/commands/groups/UnClimb.java
+++ b/src/main/java/frc/alotobots/reefscape/commands/groups/UnClimb.java
@@ -16,21 +16,24 @@ import edu.wpi.first.wpilibj2.command.*;
 import frc.alotobots.reefscape.subsystems.climber.ClimberSubsystem;
 
 /**
- * Default command that runs the elevator at a specified velocity. This command takes a velocity
- * input (normalized between -1.0 and 1.0) and applies it to the elevator, scaled by the maximum
- * speed constant.
+ * A sequential command group that handles the unclimbing sequence. This command executes a series
+ * of steps to safely disengage the climbing mechanism: 1. Enables the servos 2. Sets the plunger to
+ * receive position 3. Unlocks the cage 4. Waits for 1 second 5. Disables the servos
  */
 public class UnClimb extends SequentialCommandGroup {
 
+  /**
+   * Creates a new UnClimb command.
+   *
+   * @param climberSubsystem The climber subsystem to control
+   */
   public UnClimb(ClimberSubsystem climberSubsystem) {
-
     addCommands(
         new InstantCommand(climberSubsystem::enableServos),
         new InstantCommand(climberSubsystem::setPlungerToReceive),
         new InstantCommand(climberSubsystem::unlockCage),
         new WaitCommand(1),
-        new InstantCommand(climberSubsystem::disableServos)
-        );
+        new InstantCommand(climberSubsystem::disableServos));
     addRequirements(climberSubsystem);
   }
 }

--- a/src/main/java/frc/alotobots/reefscape/subsystems/climber/ClimberSubsystem.java
+++ b/src/main/java/frc/alotobots/reefscape/subsystems/climber/ClimberSubsystem.java
@@ -20,74 +20,101 @@ import frc.alotobots.reefscape.subsystems.climber.io.ClimberIO;
 import frc.alotobots.reefscape.subsystems.climber.io.ClimberIOInputsAutoLogged;
 import org.littletonrobotics.junction.Logger;
 
+/**
+ * A subsystem that controls the robot's climbing mechanism. This subsystem manages two servos: - A
+ * plunger servo that can move between receive (180°) and plunge (0°) positions - A locking servo
+ * that secures the climbing cage
+ */
 public class ClimberSubsystem extends SubsystemBase {
+  /** The hardware interface for the climber */
   private final ClimberIO io;
+
+  /** The logged inputs from the climber hardware */
   private final ClimberIOInputsAutoLogged inputs = new ClimberIOInputsAutoLogged();
 
+  /**
+   * Creates a new ClimberSubsystem.
+   *
+   * @param io The hardware interface for the climber
+   */
   public ClimberSubsystem(ClimberIO io) {
     this.io = io;
   }
 
+  /** Periodic update function that logs climber inputs. Called once per scheduler run. */
   @Override
   public void periodic() {
     io.updateInputs(inputs);
     Logger.processInputs("Climber", inputs);
   }
 
+  /**
+   * Gets the state of the cage limit switches.
+   *
+   * @return true if the cage switches are activated
+   */
   public boolean getCageSwitches() {
     return io.getCageSwitches();
   }
 
+  /** Enables both the plunger and locking servos. */
   public void enableServos() {
     io.enablePlungerServo();
     io.enableLockingServo();
   }
 
+  /** Disables both the plunger and locking servos. */
   public void disableServos() {
     io.disablePlungerServo();
     io.disableLockingServo();
   }
 
   /**
-   * Sets the plunger servo position based on an angle.
+   * Sets the plunger servo to a specific angle. 0 degrees is the plunge position, 180 degrees is
+   * the receive position.
    *
-   * @param angle The desired angle, where: - 0 degrees = down/plunge position (PLUNGER_SERVO_0_PW)
-   *     - 180 degrees = up/receive position (PLUNGER_SERVO_180_PW) The angle is mapped to pulse
-   *     width: - Maps 0° → PLUNGER_SERVO_0_PW (plunge/down position) - Maps 180° →
-   *     PLUNGER_SERVO_180_PW (receive/up position)
+   * @param angle The desired angle for the plunger servo
    */
   public void setPlungerToAngle(Angle angle) {
     io.setPlungerServoPosition(angle);
   }
 
+  /** Locks the climbing cage using the locking servo. */
   public void lockCage() {
     io.setLockingServoLocked(true);
   }
 
+  /** Unlocks the climbing cage using the locking servo. */
   public void unlockCage() {
     io.setLockingServoLocked(false);
   }
 
+  /** Enables only the plunger servo. */
   public void enablePlungerServo() {
     io.enablePlungerServo();
   }
 
+  /** Enables only the locking servo. */
   public void enableLockingServo() {
     io.enableLockingServo();
   }
 
+  /** Disables only the plunger servo. */
   public void disablePlungerServo() {
     io.disablePlungerServo();
   }
 
+  /** Disables only the locking servo. */
   public void disableLockingServo() {
     io.disableLockingServo();
   }
 
+  /** Sets the plunger servo to its receive position (180 degrees). */
   public void setPlungerToReceive() {
     io.setPlungerServoPosition(Degrees.of(180));
   }
 
+  /** Sets the plunger servo to its plunge position (0 degrees). */
   public void setPlungerToPlunge() {
     io.setPlungerServoPosition(Degrees.of(0));
   }

--- a/src/main/java/frc/alotobots/reefscape/subsystems/climber/commands/ClimberDisableServos.java
+++ b/src/main/java/frc/alotobots/reefscape/subsystems/climber/commands/ClimberDisableServos.java
@@ -1,0 +1,21 @@
+package frc.alotobots.reefscape.subsystems.climber.commands;
+
+import edu.wpi.first.wpilibj2.command.InstantCommand;
+import frc.alotobots.reefscape.subsystems.climber.ClimberSubsystem;
+
+public class ClimberDisableServos extends InstantCommand {
+    private final ClimberSubsystem climberSubsystem;
+    public ClimberDisableServos(ClimberSubsystem climberSubsystem) {
+        this.climberSubsystem = climberSubsystem;
+    }
+
+    @Override
+    public void initialize() {
+        climberSubsystem.disableServos();
+    }
+
+    @Override
+    public boolean runsWhenDisabled() {
+        return true;
+    }
+}

--- a/src/main/java/frc/alotobots/reefscape/subsystems/climber/commands/ClimberDisableServos.java
+++ b/src/main/java/frc/alotobots/reefscape/subsystems/climber/commands/ClimberDisableServos.java
@@ -1,21 +1,52 @@
+/*
+* ALOTOBOTS - FRC Team 5152
+  https://github.com/5152Alotobots
+* Copyright (C) 2025 ALOTOBOTS
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* Source code must be publicly available on GitHub or an alternative web accessible site
+*/
 package frc.alotobots.reefscape.subsystems.climber.commands;
 
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import frc.alotobots.reefscape.subsystems.climber.ClimberSubsystem;
 
+/**
+ * A command that disables the servos in the climber subsystem. This command executes instantly and
+ * can run when the robot is disabled.
+ */
 public class ClimberDisableServos extends InstantCommand {
-    private final ClimberSubsystem climberSubsystem;
-    public ClimberDisableServos(ClimberSubsystem climberSubsystem) {
-        this.climberSubsystem = climberSubsystem;
-    }
+  /** The climber subsystem instance this command operates on */
+  private final ClimberSubsystem climberSubsystem;
 
-    @Override
-    public void initialize() {
-        climberSubsystem.disableServos();
-    }
+  /**
+   * Creates a new ClimberDisableServos command.
+   *
+   * @param climberSubsystem The climber subsystem to control
+   */
+  public ClimberDisableServos(ClimberSubsystem climberSubsystem) {
+    this.climberSubsystem = climberSubsystem;
+  }
 
-    @Override
-    public boolean runsWhenDisabled() {
-        return true;
-    }
+  /**
+   * Called when the command is initially scheduled. Disables the servos in the climber subsystem.
+   */
+  @Override
+  public void initialize() {
+    climberSubsystem.disableServos();
+  }
+
+  /**
+   * Returns whether this command can run when the robot is disabled.
+   *
+   * @return true, allowing this command to run when the robot is disabled
+   */
+  @Override
+  public boolean runsWhenDisabled() {
+    return true;
+  }
 }

--- a/src/main/java/frc/alotobots/reefscape/subsystems/climber/constants/ClimberRevServoRealConstants.java
+++ b/src/main/java/frc/alotobots/reefscape/subsystems/climber/constants/ClimberRevServoRealConstants.java
@@ -1,29 +1,46 @@
+/*
+* ALOTOBOTS - FRC Team 5152
+  https://github.com/5152Alotobots
+* Copyright (C) 2025 ALOTOBOTS
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* Source code must be publicly available on GitHub or an alternative web accessible site
+*/
 package frc.alotobots.reefscape.subsystems.climber.constants;
 
 import com.revrobotics.servohub.ServoChannel;
 
 /**
- * Constants for the real servo configuration in the climber subsystem.
- * This class contains the IDs and pulse widths for the plunger and locking servos,
- * as well as the IDs for the cage limit switches.
+ * Constants for the real servo configuration in the climber subsystem. This class contains the IDs
+ * and pulse widths for the plunger and locking servos, as well as the IDs for the cage limit
+ * switches.
  */
 public final class ClimberRevServoRealConstants {
   /** The channel ID for the plunger servo */
   public static final ServoChannel.ChannelId PLUNGER_SERVO_ID = ServoChannel.ChannelId.kChannelId2;
+
   /** The channel ID for the locking servo */
   public static final ServoChannel.ChannelId LOCKING_SERVO_ID = ServoChannel.ChannelId.kChannelId0;
 
   /** The ID for the first cage limit switch */
   public static final int CAGE_SWITCH_1_ID = 0;
+
   /** The ID for the second cage limit switch */
   public static final int CAGE_SWITCH_2_ID = 1;
 
   /** The pulse width for the plunger servo at 0 degrees */
   public static final int PLUNGER_SERVO_0_PW = 650;
+
   /** The pulse width for the plunger servo at 180 degrees */
   public static final int PLUNGER_SERVO_180_PW = 2500;
+
   /** The pulse width for the locking servo in the open position */
   public static final int LOCKING_SERVO_OPEN_PW = 1773;
+
   /** The pulse width for the locking servo in the closed position */
   public static final int LOCKING_SERVO_CLOSED_PW = 1446;
 }

--- a/src/main/java/frc/alotobots/reefscape/subsystems/climber/constants/ClimberRevServoRealConstants.java
+++ b/src/main/java/frc/alotobots/reefscape/subsystems/climber/constants/ClimberRevServoRealConstants.java
@@ -14,7 +14,7 @@ package frc.alotobots.reefscape.subsystems.climber.constants;
 
 import com.revrobotics.servohub.ServoChannel.ChannelId;
 
-public final class ClimberRevServoReal {
+public final class ClimberRevServoRealConstants {
   public static final ChannelId PLUNGER_SERVO_ID = ChannelId.kChannelId2;
   public static final ChannelId LOCKING_SERVO_ID = ChannelId.kChannelId0;
 

--- a/src/main/java/frc/alotobots/reefscape/subsystems/climber/constants/ClimberRevServoRealConstants.java
+++ b/src/main/java/frc/alotobots/reefscape/subsystems/climber/constants/ClimberRevServoRealConstants.java
@@ -1,28 +1,29 @@
-/*
-* ALOTOBOTS - FRC Team 5152
-  https://github.com/5152Alotobots
-* Copyright (C) 2025 ALOTOBOTS
-*
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-*
-* Source code must be publicly available on GitHub or an alternative web accessible site
-*/
 package frc.alotobots.reefscape.subsystems.climber.constants;
 
-import com.revrobotics.servohub.ServoChannel.ChannelId;
+import com.revrobotics.servohub.ServoChannel;
 
+/**
+ * Constants for the real servo configuration in the climber subsystem.
+ * This class contains the IDs and pulse widths for the plunger and locking servos,
+ * as well as the IDs for the cage limit switches.
+ */
 public final class ClimberRevServoRealConstants {
-  public static final ChannelId PLUNGER_SERVO_ID = ChannelId.kChannelId2;
-  public static final ChannelId LOCKING_SERVO_ID = ChannelId.kChannelId0;
+  /** The channel ID for the plunger servo */
+  public static final ServoChannel.ChannelId PLUNGER_SERVO_ID = ServoChannel.ChannelId.kChannelId2;
+  /** The channel ID for the locking servo */
+  public static final ServoChannel.ChannelId LOCKING_SERVO_ID = ServoChannel.ChannelId.kChannelId0;
 
+  /** The ID for the first cage limit switch */
   public static final int CAGE_SWITCH_1_ID = 0;
+  /** The ID for the second cage limit switch */
   public static final int CAGE_SWITCH_2_ID = 1;
 
+  /** The pulse width for the plunger servo at 0 degrees */
   public static final int PLUNGER_SERVO_0_PW = 650;
+  /** The pulse width for the plunger servo at 180 degrees */
   public static final int PLUNGER_SERVO_180_PW = 2500;
+  /** The pulse width for the locking servo in the open position */
   public static final int LOCKING_SERVO_OPEN_PW = 1773;
+  /** The pulse width for the locking servo in the closed position */
   public static final int LOCKING_SERVO_CLOSED_PW = 1446;
 }

--- a/src/main/java/frc/alotobots/reefscape/subsystems/climber/io/ClimberIO.java
+++ b/src/main/java/frc/alotobots/reefscape/subsystems/climber/io/ClimberIO.java
@@ -21,40 +21,43 @@ import edu.wpi.first.units.measure.Voltage;
 import org.littletonrobotics.junction.AutoLog;
 
 /**
- * Interface for controlling the climber's hardware components.
- * This interface defines methods for controlling two servos and reading various sensor inputs:
- * - A plunger servo that moves between receive and plunge positions
- * - A locking servo that secures the climbing cage
- * - Cage limit switches for detecting if the climbing mechanism is engaged
+ * Interface for controlling the climber's hardware components. This interface defines methods for
+ * controlling two servos and reading various sensor inputs: - A plunger servo that moves between
+ * receive and plunge positions - A locking servo that secures the climbing cage - Cage limit
+ * switches for detecting if the climbing mechanism is engaged
  */
 public interface ClimberIO {
 
-  /**
-   * AutoLogged class that contains all the inputs from the climber hardware.
-   */
+  /** AutoLogged class that contains all the inputs from the climber hardware. */
   @AutoLog
   public static class ClimberIOInputs {
     /** Connection status of the servo hub */
     public boolean servoHubConnected = false;
+
     /** Current voltage of the servo hub */
     public Voltage servoHubVoltage = Volts.zero();
+
     /** Current draw of the servo hub */
     public Current servoHubCurrent = Amps.zero();
+
     /** Voltage supplied to the servos */
     public Voltage servoHubServoVoltage = Volts.zero();
 
     /** Enable state of the locking servo */
     public boolean lockingServoEnabled = false;
+
     /** Enable state of the plunger servo */
     public boolean plungerServoEnabled = false;
 
     /** State of the first cage limit switch */
     public boolean cageSwitch1 = false;
+
     /** State of the second cage limit switch */
     public boolean cageSwitch2 = false;
 
     /** Current pulse width of the plunger servo */
     public int plungerServoPulseWidth = 0;
+
     /** Current pulse width of the locking servo */
     public int lockingServoPulseWidth = 0;
   }
@@ -73,24 +76,16 @@ public interface ClimberIO {
    */
   public void updateInputs(ClimberIOInputs inputs);
 
-  /**
-   * Enables the locking servo.
-   */
+  /** Enables the locking servo. */
   public void enableLockingServo();
 
-  /**
-   * Disables the locking servo.
-   */
+  /** Disables the locking servo. */
   public void disableLockingServo();
 
-  /**
-   * Enables the plunger servo.
-   */
+  /** Enables the plunger servo. */
   public void enablePlungerServo();
 
-  /**
-   * Disables the plunger servo.
-   */
+  /** Disables the plunger servo. */
   public void disablePlungerServo();
 
   /**

--- a/src/main/java/frc/alotobots/reefscape/subsystems/climber/io/ClimberIO.java
+++ b/src/main/java/frc/alotobots/reefscape/subsystems/climber/io/ClimberIO.java
@@ -20,39 +20,90 @@ import edu.wpi.first.units.measure.Current;
 import edu.wpi.first.units.measure.Voltage;
 import org.littletonrobotics.junction.AutoLog;
 
+/**
+ * Interface for controlling the climber's hardware components.
+ * This interface defines methods for controlling two servos and reading various sensor inputs:
+ * - A plunger servo that moves between receive and plunge positions
+ * - A locking servo that secures the climbing cage
+ * - Cage limit switches for detecting if the climbing mechanism is engaged
+ */
 public interface ClimberIO {
 
+  /**
+   * AutoLogged class that contains all the inputs from the climber hardware.
+   */
   @AutoLog
   public static class ClimberIOInputs {
+    /** Connection status of the servo hub */
     public boolean servoHubConnected = false;
+    /** Current voltage of the servo hub */
     public Voltage servoHubVoltage = Volts.zero();
+    /** Current draw of the servo hub */
     public Current servoHubCurrent = Amps.zero();
-
+    /** Voltage supplied to the servos */
     public Voltage servoHubServoVoltage = Volts.zero();
 
+    /** Enable state of the locking servo */
     public boolean lockingServoEnabled = false;
+    /** Enable state of the plunger servo */
     public boolean plungerServoEnabled = false;
 
+    /** State of the first cage limit switch */
     public boolean cageSwitch1 = false;
+    /** State of the second cage limit switch */
     public boolean cageSwitch2 = false;
 
+    /** Current pulse width of the plunger servo */
     public int plungerServoPulseWidth = 0;
+    /** Current pulse width of the locking servo */
     public int lockingServoPulseWidth = 0;
   }
 
+  /**
+   * Gets the state of both cage limit switches.
+   *
+   * @return true if both cage switches are activated
+   */
   boolean getCageSwitches();
 
+  /**
+   * Updates the input values with current hardware states.
+   *
+   * @param inputs The ClimberIOInputs object to update
+   */
   public void updateInputs(ClimberIOInputs inputs);
 
+  /**
+   * Enables the locking servo.
+   */
   public void enableLockingServo();
 
+  /**
+   * Disables the locking servo.
+   */
   public void disableLockingServo();
 
+  /**
+   * Enables the plunger servo.
+   */
   public void enablePlungerServo();
 
+  /**
+   * Disables the plunger servo.
+   */
   public void disablePlungerServo();
 
+  /**
+   * Sets the position of the plunger servo.
+   *
+   * @param angle The desired angle for the plunger servo
+   */
   public void setPlungerServoPosition(Angle angle);
 
+  /**
+   * Sets the locked state of the locking servo.
+   *
+   * @param lockingServoLocked true to lock, false to unlock
+   */
   public void setLockingServoLocked(boolean lockingServoLocked);
 }

--- a/src/main/java/frc/alotobots/reefscape/subsystems/climber/io/ClimberIORevServoReal.java
+++ b/src/main/java/frc/alotobots/reefscape/subsystems/climber/io/ClimberIORevServoReal.java
@@ -22,27 +22,29 @@ import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.wpilibj.DigitalInput;
 
 /**
- * Implementation of ClimberIO for REV Robotics Servo Hub hardware.
- * Controls two servos for climbing mechanism:
- * - A plunger servo that moves between up/down positions
- * - A locking servo that engages/disengages a lock
- * Also monitors two limit switches that detect cage position.
+ * Implementation of ClimberIO for REV Robotics Servo Hub hardware. Controls two servos for climbing
+ * mechanism: - A plunger servo that moves between up/down positions - A locking servo that
+ * engages/disengages a lock Also monitors two limit switches that detect cage position.
  */
 public class ClimberIORevServoReal implements ClimberIO {
   /** REV Robotics Servo Hub controller */
   private final ServoHub servoHub = new ServoHub(SERVO_HUB_CAN_ID);
+
   /** Channel for the plunger servo */
   private final ServoChannel plungerServoChannel = servoHub.getServoChannel(PLUNGER_SERVO_ID);
+
   /** Channel for the locking servo */
   private final ServoChannel lockingServoChannel = servoHub.getServoChannel(LOCKING_SERVO_ID);
+
   /** First limit switch for detecting cage position */
   private final DigitalInput cageSwitch1 = new DigitalInput(CAGE_SWITCH_1_ID);
+
   /** Second limit switch for detecting cage position */
   private final DigitalInput cageSwitch2 = new DigitalInput(CAGE_SWITCH_2_ID);
 
   /**
-   * Initializes the climber hardware.
-   * Briefly enables then disables both servos to ensure proper initialization.
+   * Initializes the climber hardware. Briefly enables then disables both servos to ensure proper
+   * initialization.
    */
   public ClimberIORevServoReal() {
     enablePlungerServo();
@@ -54,6 +56,7 @@ public class ClimberIORevServoReal implements ClimberIO {
 
   /**
    * Gets the state of both cage limit switches.
+   *
    * @return true if both switches are triggered, false otherwise
    */
   @Override
@@ -63,6 +66,7 @@ public class ClimberIORevServoReal implements ClimberIO {
 
   /**
    * Updates all input values from hardware sensors.
+   *
    * @param inputs The inputs object to update with current hardware state
    */
   @Override
@@ -82,36 +86,28 @@ public class ClimberIORevServoReal implements ClimberIO {
     inputs.plungerServoPulseWidth = plungerServoChannel.getPulseWidth();
   }
 
-  /**
-   * Enables power and control to the plunger servo.
-   */
+  /** Enables power and control to the plunger servo. */
   @Override
   public void enablePlungerServo() {
     plungerServoChannel.setEnabled(true);
     plungerServoChannel.setPowered(true);
   }
 
-  /**
-   * Enables power and control to the locking servo.
-   */
+  /** Enables power and control to the locking servo. */
   @Override
   public void enableLockingServo() {
     lockingServoChannel.setEnabled(true);
     lockingServoChannel.setPowered(true);
   }
 
-  /**
-   * Disables power and control to the plunger servo.
-   */
+  /** Disables power and control to the plunger servo. */
   @Override
   public void disablePlungerServo() {
     plungerServoChannel.setEnabled(false);
     plungerServoChannel.setPowered(false);
   }
 
-  /**
-   * Disables power and control to the locking servo.
-   */
+  /** Disables power and control to the locking servo. */
   @Override
   public void disableLockingServo() {
     lockingServoChannel.setEnabled(false);
@@ -121,12 +117,10 @@ public class ClimberIORevServoReal implements ClimberIO {
   /**
    * Sets the plunger servo position based on an angle.
    *
-   * @param angle The desired angle, where:
-   *     - 0 degrees = down/plunge position (PLUNGER_SERVO_0_PW)
-   *     - 180 degrees = up/receive position (PLUNGER_SERVO_180_PW)
-   *     The angle is mapped to pulse width:
-   *     - Maps 0° → PLUNGER_SERVO_0_PW (plunge/down position)
-   *     - Maps 180° → PLUNGER_SERVO_180_PW (receive/up position)
+   * @param angle The desired angle, where: - 0 degrees = down/plunge position (PLUNGER_SERVO_0_PW)
+   *     - 180 degrees = up/receive position (PLUNGER_SERVO_180_PW) The angle is mapped to pulse
+   *     width: - Maps 0° → PLUNGER_SERVO_0_PW (plunge/down position) - Maps 180° →
+   *     PLUNGER_SERVO_180_PW (receive/up position)
    */
   @Override
   public void setPlungerServoPosition(Angle angle) {
@@ -138,6 +132,7 @@ public class ClimberIORevServoReal implements ClimberIO {
 
   /**
    * Sets the locking servo to either locked or unlocked position.
+   *
    * @param lockingServoLocked true to lock, false to unlock
    */
   @Override

--- a/src/main/java/frc/alotobots/reefscape/subsystems/climber/io/ClimberIORevServoReal.java
+++ b/src/main/java/frc/alotobots/reefscape/subsystems/climber/io/ClimberIORevServoReal.java
@@ -21,13 +21,29 @@ import com.revrobotics.servohub.ServoHub;
 import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.wpilibj.DigitalInput;
 
+/**
+ * Implementation of ClimberIO for REV Robotics Servo Hub hardware.
+ * Controls two servos for climbing mechanism:
+ * - A plunger servo that moves between up/down positions
+ * - A locking servo that engages/disengages a lock
+ * Also monitors two limit switches that detect cage position.
+ */
 public class ClimberIORevServoReal implements ClimberIO {
+  /** REV Robotics Servo Hub controller */
   private final ServoHub servoHub = new ServoHub(SERVO_HUB_CAN_ID);
+  /** Channel for the plunger servo */
   private final ServoChannel plungerServoChannel = servoHub.getServoChannel(PLUNGER_SERVO_ID);
+  /** Channel for the locking servo */
   private final ServoChannel lockingServoChannel = servoHub.getServoChannel(LOCKING_SERVO_ID);
+  /** First limit switch for detecting cage position */
   private final DigitalInput cageSwitch1 = new DigitalInput(CAGE_SWITCH_1_ID);
+  /** Second limit switch for detecting cage position */
   private final DigitalInput cageSwitch2 = new DigitalInput(CAGE_SWITCH_2_ID);
 
+  /**
+   * Initializes the climber hardware.
+   * Briefly enables then disables both servos to ensure proper initialization.
+   */
   public ClimberIORevServoReal() {
     enablePlungerServo();
     enableLockingServo();
@@ -36,11 +52,19 @@ public class ClimberIORevServoReal implements ClimberIO {
     disableLockingServo();
   }
 
+  /**
+   * Gets the state of both cage limit switches.
+   * @return true if both switches are triggered, false otherwise
+   */
   @Override
   public boolean getCageSwitches() {
     return cageSwitch1.get() && cageSwitch2.get();
   }
 
+  /**
+   * Updates all input values from hardware sensors.
+   * @param inputs The inputs object to update with current hardware state
+   */
   @Override
   public void updateInputs(ClimberIOInputs inputs) {
     inputs.plungerServoEnabled = plungerServoChannel.isEnabled();
@@ -58,24 +82,36 @@ public class ClimberIORevServoReal implements ClimberIO {
     inputs.plungerServoPulseWidth = plungerServoChannel.getPulseWidth();
   }
 
+  /**
+   * Enables power and control to the plunger servo.
+   */
   @Override
   public void enablePlungerServo() {
     plungerServoChannel.setEnabled(true);
     plungerServoChannel.setPowered(true);
   }
 
+  /**
+   * Enables power and control to the locking servo.
+   */
   @Override
   public void enableLockingServo() {
     lockingServoChannel.setEnabled(true);
     lockingServoChannel.setPowered(true);
   }
 
+  /**
+   * Disables power and control to the plunger servo.
+   */
   @Override
   public void disablePlungerServo() {
     plungerServoChannel.setEnabled(false);
     plungerServoChannel.setPowered(false);
   }
 
+  /**
+   * Disables power and control to the locking servo.
+   */
   @Override
   public void disableLockingServo() {
     lockingServoChannel.setEnabled(false);
@@ -85,10 +121,12 @@ public class ClimberIORevServoReal implements ClimberIO {
   /**
    * Sets the plunger servo position based on an angle.
    *
-   * @param angle The desired angle, where: - 0 degrees = down/plunge position (PLUNGER_SERVO_0_PW)
-   *     - 180 degrees = up/receive position (PLUNGER_SERVO_180_PW) The angle is mapped to pulse
-   *     width: - Maps 0° → PLUNGER_SERVO_0_PW (plunge/down position) - Maps 180° →
-   *     PLUNGER_SERVO_180_PW (receive/up position)
+   * @param angle The desired angle, where:
+   *     - 0 degrees = down/plunge position (PLUNGER_SERVO_0_PW)
+   *     - 180 degrees = up/receive position (PLUNGER_SERVO_180_PW)
+   *     The angle is mapped to pulse width:
+   *     - Maps 0° → PLUNGER_SERVO_0_PW (plunge/down position)
+   *     - Maps 180° → PLUNGER_SERVO_180_PW (receive/up position)
    */
   @Override
   public void setPlungerServoPosition(Angle angle) {
@@ -98,6 +136,10 @@ public class ClimberIORevServoReal implements ClimberIO {
                 + PLUNGER_SERVO_0_PW));
   }
 
+  /**
+   * Sets the locking servo to either locked or unlocked position.
+   * @param lockingServoLocked true to lock, false to unlock
+   */
   @Override
   public void setLockingServoLocked(boolean lockingServoLocked) {
     if (lockingServoLocked) lockingServoChannel.setPulseWidth(LOCKING_SERVO_CLOSED_PW);

--- a/src/main/java/frc/alotobots/reefscape/subsystems/climber/io/ClimberIORevServoReal.java
+++ b/src/main/java/frc/alotobots/reefscape/subsystems/climber/io/ClimberIORevServoReal.java
@@ -14,7 +14,7 @@ package frc.alotobots.reefscape.subsystems.climber.io;
 
 import static edu.wpi.first.units.Units.*;
 import static frc.alotobots.Constants.CanId.SERVO_HUB_CAN_ID;
-import static frc.alotobots.reefscape.subsystems.climber.constants.ClimberRevServoReal.*;
+import static frc.alotobots.reefscape.subsystems.climber.constants.ClimberRevServoRealConstants.*;
 
 import com.revrobotics.servohub.ServoChannel;
 import com.revrobotics.servohub.ServoHub;

--- a/src/main/java/frc/alotobots/reefscape/subsystems/elevator/ElevatorSubsystem.java
+++ b/src/main/java/frc/alotobots/reefscape/subsystems/elevator/ElevatorSubsystem.java
@@ -101,7 +101,8 @@ public class ElevatorSubsystem extends SubsystemBase {
   }
 
   /**
-   * Controls the elevator to move to a specified velocity using closed-loop climbing velocity control.
+   * Controls the elevator to move to a specified velocity using closed-loop climbing velocity
+   * control.
    *
    * @param velocity Target velocity in meters per second, automatically constrained between
    *     -MAX_SPEED and MAX_SPEED

--- a/src/main/java/frc/alotobots/reefscape/subsystems/elevator/ElevatorSubsystem.java
+++ b/src/main/java/frc/alotobots/reefscape/subsystems/elevator/ElevatorSubsystem.java
@@ -101,6 +101,23 @@ public class ElevatorSubsystem extends SubsystemBase {
   }
 
   /**
+   * Controls the elevator to move to a specified velocity using closed-loop climbing velocity control.
+   *
+   * @param velocity Target velocity in meters per second, automatically constrained between
+   *     -MAX_SPEED and MAX_SPEED
+   */
+  public void runToClimbingVelocity(LinearVelocity velocity) {
+    LinearVelocity adjustedVelocity =
+        MetersPerSecond.of(
+            MathUtil.clamp(
+                velocity.in(MetersPerSecond),
+                -MAX_SPEED.in(MetersPerSecond),
+                MAX_SPEED.in(MetersPerSecond)));
+    io.setElevatorVelocity(adjustedVelocity, ControlType.ClosedLoop.VELOCITY_CLIMB.ordinal());
+    Logger.recordOutput("Elevator/ControlType", ControlType.ClosedLoop.VELOCITY_CLIMB);
+  }
+
+  /**
    * Controls the elevator using direct percent output (open-loop control). The output is clamped to
    * prevent excessive speed.
    *

--- a/src/main/java/frc/alotobots/reefscape/subsystems/elevator/commands/ClimbingElevatorRunAtVelocity.java
+++ b/src/main/java/frc/alotobots/reefscape/subsystems/elevator/commands/ClimbingElevatorRunAtVelocity.java
@@ -1,0 +1,99 @@
+/*
+* ALOTOBOTS - FRC Team 5152
+  https://github.com/5152Alotobots
+* Copyright (C) 2025 ALOTOBOTS
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* Source code must be publicly available on GitHub or an alternative web accessible site
+*/
+package frc.alotobots.reefscape.subsystems.elevator.commands;
+
+import static frc.alotobots.OI.AxisLimits.MAX_AXIS_LIMIT;
+import static frc.alotobots.OI.AxisLimits.MIN_AXIS_LIMIT;
+import static frc.alotobots.reefscape.subsystems.elevator.constants.ElevatorConstants.Limits.MAX_SPEED;
+
+import edu.wpi.first.math.MathUtil;
+import edu.wpi.first.units.measure.LinearVelocity;
+import edu.wpi.first.wpilibj2.command.Command;
+import frc.alotobots.reefscape.subsystems.elevator.ElevatorSubsystem;
+import java.util.function.DoubleSupplier;
+
+/**
+ * Command that runs the elevator at a specified velocity for climbing. This command takes a velocity
+ * input (normalized between -1.0 and 1.0) and applies it to the elevator, scaled by the maximum
+ * speed constant.
+ */
+public class ClimbingElevatorRunAtVelocity extends Command {
+  /** The elevator subsystem this command controls. */
+  private final ElevatorSubsystem elevatorSubsystem;
+
+  /**
+   * Supplier for the input value that determines velocity direction and magnitude. Expected range
+   * is between -1.0 and 1.0, where:
+   *
+   * <ul>
+   *   <li>Positive values move the elevator upward
+   *   <li>Negative values move the elevator downward
+   *   <li>Zero stops the elevator
+   * </ul>
+   */
+  private final DoubleSupplier input;
+
+  /**
+   * Creates a new ClimbingElevatorRunAtVelocity command.
+   *
+   * @param elevatorSubsystem The elevator subsystem this command will run on
+   * @param input A supplier that provides the normalized velocity input (-1.0 to 1.0)
+   */
+  public ClimbingElevatorRunAtVelocity(ElevatorSubsystem elevatorSubsystem, DoubleSupplier input) {
+    this.elevatorSubsystem = elevatorSubsystem;
+    this.input = input;
+
+    // This command requires the elevator subsystem
+    addRequirements(elevatorSubsystem);
+  }
+
+  /**
+   * Called when the command is initially scheduled. No initialization is needed for this command.
+   */
+  @Override
+  public void initialize() {}
+
+  /**
+   * Called repeatedly when this command is scheduled to run. Calculates the target velocity by
+   * multiplying the input value by the maximum speed, then commands the elevator subsystem to run
+   * at that velocity.
+   */
+  @Override
+  public void execute() {
+    double adjustedInput = MathUtil.clamp(input.getAsDouble(), MIN_AXIS_LIMIT, MAX_AXIS_LIMIT);
+    LinearVelocity velocity = MAX_SPEED.times(adjustedInput);
+    elevatorSubsystem.runToClimbingVelocity(velocity);
+  }
+
+  /**
+   * Called once when the command ends or is interrupted. Stops the elevator to ensure it doesn't
+   * continue moving.
+   *
+   * @param interrupted Whether the command was interrupted (true) or completed normally (false)
+   */
+  @Override
+  public void end(boolean interrupted) {
+    elevatorSubsystem.stop();
+  }
+
+  /**
+   * Returns whether this command has finished. This command never finishes on its own and will run
+   * until interrupted.
+   *
+   * @return false always, as this is a default command that should not terminate
+   */
+  @Override
+  public boolean isFinished() {
+    return false;
+  }
+}

--- a/src/main/java/frc/alotobots/reefscape/subsystems/elevator/commands/ElevatorRunAtClimbVelocity.java
+++ b/src/main/java/frc/alotobots/reefscape/subsystems/elevator/commands/ElevatorRunAtClimbVelocity.java
@@ -27,7 +27,7 @@ import java.util.function.DoubleSupplier;
  * input (normalized between -1.0 and 1.0) and applies it to the elevator, scaled by the maximum
  * speed constant.
  */
-public class ClimbingElevatorRunAtVelocity extends Command {
+public class ElevatorRunAtClimbVelocity extends Command {
   /** The elevator subsystem this command controls. */
   private final ElevatorSubsystem elevatorSubsystem;
 
@@ -49,7 +49,7 @@ public class ClimbingElevatorRunAtVelocity extends Command {
    * @param elevatorSubsystem The elevator subsystem this command will run on
    * @param input A supplier that provides the normalized velocity input (-1.0 to 1.0)
    */
-  public ClimbingElevatorRunAtVelocity(ElevatorSubsystem elevatorSubsystem, DoubleSupplier input) {
+  public ElevatorRunAtClimbVelocity(ElevatorSubsystem elevatorSubsystem, DoubleSupplier input) {
     this.elevatorSubsystem = elevatorSubsystem;
     this.input = input;
 

--- a/src/main/java/frc/alotobots/reefscape/subsystems/elevator/commands/ElevatorRunAtClimbVelocity.java
+++ b/src/main/java/frc/alotobots/reefscape/subsystems/elevator/commands/ElevatorRunAtClimbVelocity.java
@@ -23,9 +23,9 @@ import frc.alotobots.reefscape.subsystems.elevator.ElevatorSubsystem;
 import java.util.function.DoubleSupplier;
 
 /**
- * Command that runs the elevator at a specified velocity for climbing. This command takes a velocity
- * input (normalized between -1.0 and 1.0) and applies it to the elevator, scaled by the maximum
- * speed constant.
+ * Command that runs the elevator at a specified velocity for climbing. This command takes a
+ * velocity input (normalized between -1.0 and 1.0) and applies it to the elevator, scaled by the
+ * maximum speed constant.
  */
 public class ElevatorRunAtClimbVelocity extends Command {
   /** The elevator subsystem this command controls. */

--- a/src/main/java/frc/alotobots/reefscape/subsystems/elevator/constants/ElevatorConstants.java
+++ b/src/main/java/frc/alotobots/reefscape/subsystems/elevator/constants/ElevatorConstants.java
@@ -55,6 +55,8 @@ public final class ElevatorConstants {
     /** Height when elevator is fully retracted/stowed */
     public static final Distance STOWED = Meters.of(0.3);
 
+    public static final Distance CLIMB = Meters.of(0.8);
+
     /** Height for picking up from coral station */
     public static final Distance CORAL_STATION = Meters.of(0.80);
 

--- a/src/main/java/frc/alotobots/reefscape/subsystems/elevator/constants/ElevatorTalonFXRealConstants.java
+++ b/src/main/java/frc/alotobots/reefscape/subsystems/elevator/constants/ElevatorTalonFXRealConstants.java
@@ -75,6 +75,30 @@ public final class ElevatorTalonFXRealConstants {
       /** Velocity feedforward gain */
       public static final double KV = 0.0;
     }
+
+    /** TalonFX-specific PID and motion control constants for climbing mode. */
+    public static final class ClimbingPIDConstants {
+      /** Climbing control proportional gain */
+      public static final double KP = 0.2;
+
+      /** Climbing control integral gain */
+      public static final double KI = 0.0;
+
+      /** Climbing control derivative gain */
+      public static final double KD = 0.0;
+
+      /** Acceleration feedforward gain */
+      public static final double KA = 0.0;
+
+      /** Gravity compensation gain */
+      public static final double KG = 0.15;
+
+      /** Static friction compensation */
+      public static final double KS = 0.0;
+
+      /** Velocity feedforward gain */
+      public static final double KV = 0.12;
+    }
   }
 
   /** Contains safety limit constants for the elevator motors. */

--- a/src/main/java/frc/alotobots/reefscape/subsystems/elevator/io/ElevatorIOTalonFXReal.java
+++ b/src/main/java/frc/alotobots/reefscape/subsystems/elevator/io/ElevatorIOTalonFXReal.java
@@ -142,6 +142,16 @@ public class ElevatorIOTalonFXReal implements ElevatorIO {
     leftConfig.Slot1.kS = ElevatorTalonFXRealConstants.PIDConstants.PositionPIDConstants.KS;
     leftConfig.Slot1.kV = ElevatorTalonFXRealConstants.PIDConstants.PositionPIDConstants.KV;
 
+    // PID configuration for climbing mode (Slot 2)
+    leftConfig.Slot2.kP = ElevatorTalonFXRealConstants.PIDConstants.ClimbingPIDConstants.KP;
+    leftConfig.Slot2.kI = ElevatorTalonFXRealConstants.PIDConstants.ClimbingPIDConstants.KI;
+    leftConfig.Slot2.kD = ElevatorTalonFXRealConstants.PIDConstants.ClimbingPIDConstants.KD;
+    leftConfig.Slot2.GravityType = GravityTypeValue.Elevator_Static;
+    leftConfig.Slot2.kA = ElevatorTalonFXRealConstants.PIDConstants.ClimbingPIDConstants.KA;
+    leftConfig.Slot2.kG = ElevatorTalonFXRealConstants.PIDConstants.ClimbingPIDConstants.KG;
+    leftConfig.Slot2.kS = ElevatorTalonFXRealConstants.PIDConstants.ClimbingPIDConstants.KS;
+    leftConfig.Slot2.kV = ElevatorTalonFXRealConstants.PIDConstants.ClimbingPIDConstants.KV;
+
     leftConfig.MotorOutput.NeutralMode = MECHANISM_NEUTRAL_MODE;
 
     leftConfig.SoftwareLimitSwitch.ForwardSoftLimitEnable = LIMITS_ENABLED;

--- a/src/main/java/frc/alotobots/reefscape/util/ControlType.java
+++ b/src/main/java/frc/alotobots/reefscape/util/ControlType.java
@@ -15,7 +15,8 @@ package frc.alotobots.reefscape.util;
 public class ControlType {
   public enum ClosedLoop {
     VELOCITY,
-    POSITION
+    POSITION,
+    VELOCITY_CLIMB
   }
 
   public enum OpenLoop {


### PR DESCRIPTION
PID NOT TUNED YET

Add a new climbing PID mode to the elevator subsystem to hold the robot completely off the floor using velocity voltage.

* Add new PID constants for climbing mode in `ElevatorTalonFXRealConstants.java`.
* Add a new method `runToClimbingVelocity` in `ElevatorSubsystem.java` to control the elevator in climbing mode.
* Create a new command `ClimbingElevatorRunAtVelocity` in `ClimbingElevatorRunAtVelocity.java` to use the new climbing PID mode.
* Add a new enum entry `VELOCITY_CLIMB` in the `ClosedLoop` enum in `ControlType.java`.
* Update `RobotContainer.java` to integrate the new climbing command into the climbing command group and bind it to the appropriate button.
* Apply the new PID constants to slot2 in `ElevatorIOTalonFXReal.java`.

